### PR TITLE
 Add invertIECOutputs and ignoreReset options; fix Makefile.rules

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -30,8 +30,8 @@ endif
 
 AFLAGS	 += $(ARCH)
 CFLAGS	 += $(ARCH) -Wall -Wno-psabi -fsigned-char -fno-builtin -Ofast -DNDEBUG
-CPPFLAGS += $(CFLAGS) -fno-exceptions -fno-rtti -std=c++0x -Wno-write-strings
-CFLAGS	 += -fno-delete-null-pointer-checks -fdata-sections -ffunction-sections -u _printf_float
+CPPFLAGS := $(CFLAGS) $(CPPFLAGS) -fno-exceptions -fno-rtti -std=c++0x -Wno-write-strings
+CFLAGS	 += -fno-delete-null-pointer-checks -fdata-sections -ffunction-sections -u _printf_float -std=gnu99
 
 .PHONY: clean
 

--- a/src/Timer.c
+++ b/src/Timer.c
@@ -16,7 +16,8 @@ static void TimerPollKernelTimers()
 {
 	//EnterCritical();
 
-	for (unsigned hTimer = 0; hTimer < KERNEL_TIMERS; hTimer++)
+	unsigned hTimer;
+	for (hTimer = 0; hTimer < KERNEL_TIMERS; hTimer++)
 	{
 		volatile TKernelTimer* pTimer = &m_KernelTimer[hTimer];
 
@@ -71,7 +72,8 @@ void TimerSystemInitialize()
 	
 	DataMemBarrier();
 
-	for (unsigned hTimer = 0; hTimer < KERNEL_TIMERS; hTimer++)
+	unsigned hTimer;
+	for (hTimer = 0; hTimer < KERNEL_TIMERS; hTimer++)
 	{
 		m_KernelTimer[hTimer].m_pHandler = 0;
 	}

--- a/src/iec_bus.cpp
+++ b/src/iec_bus.cpp
@@ -44,6 +44,8 @@ bool IEC_Bus::Resetting = false;
 
 bool IEC_Bus::splitIECLines = false;
 bool IEC_Bus::invertIECInputs = false;
+bool IEC_Bus::invertIECOutputs = true;
+bool IEC_Bus::ignoreReset = false;
 
 u32 IEC_Bus::myOutsGPFSEL1 = 0;
 u32 IEC_Bus::myOutsGPFSEL0 = 0;
@@ -122,5 +124,5 @@ void IEC_Bus::Read(void)
 		if (VIA) portB->SetInput(VIAPORTPINS_CLOCKIN, true); // simulate the read in software
 	}
 
-	Resetting = (gplev0 & PIGPIO_MASK_IN_RESET) == (invertIECInputs ? PIGPIO_MASK_IN_RESET : 0);
+	Resetting = !ignoreReset && ((gplev0 & PIGPIO_MASK_IN_RESET) == (invertIECInputs ? PIGPIO_MASK_IN_RESET : 0));
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -96,7 +96,9 @@ bool quickBoot = false;
 bool displayPNGIcons = false;
 bool soundOnGPIO = false;
 bool invertIECInputs = false;
+bool invertIECOutputs = true;
 bool splitIECLines = false;
+bool ignoreReset = false;
 
 const char* termainalTextRed = "\E[31m";
 const char* termainalTextNormal = "\E[0m";
@@ -958,10 +960,11 @@ static void LoadOptions()
 		displayPNGIcons = options.DisplayPNGIcons();
 		soundOnGPIO = options.SoundOnGPIO();
 		invertIECInputs = options.InvertIECInputs();
+		invertIECOutputs = options.InvertIECOutputs();
 		splitIECLines = options.SplitIECLines();
 		if (!splitIECLines)
 			invertIECInputs = false;
-
+		ignoreReset = options.IgnoreReset();
 
 		ROMName = options.GetRomFontName();
 		if (ROMName)
@@ -1096,6 +1099,8 @@ extern "C"
 
 		IEC_Bus::SetSplitIECLines(splitIECLines);
 		IEC_Bus::SetInvertIECInputs(invertIECInputs);
+		IEC_Bus::SetInvertIECOutputs(invertIECOutputs);
+		IEC_Bus::SetIgnoreReset(ignoreReset);
 
 		if (!soundOnGPIO)
 		{

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -129,7 +129,9 @@ Options::Options(void)
 	, displayPNGIcons(0)
 	, soundOnGPIO(0)
 	, invertIECInputs(0)
+	, invertIECOutputs(1)
 	, splitIECLines(0)
+	, ignoreReset(0)
 {
 	strcpy(ROMFontName, "chargen");
 	ROMName[0] = 0;
@@ -212,11 +214,23 @@ void Options::Process(char* buffer)
 			if ((nValue = GetDecimal(pValue)) != INVALID_VALUE)
 				invertIECInputs = nValue;
 		}
+		else if (strcasecmp(pOption, "invertIECOutputs") == 0)
+		{
+			unsigned nValue = 0;
+			if ((nValue = GetDecimal(pValue)) != INVALID_VALUE)
+				invertIECOutputs = nValue;
+		}
 		else if (strcasecmp(pOption, "splitIECLines") == 0)
 		{
 			unsigned nValue = 0;
 			if ((nValue = GetDecimal(pValue)) != INVALID_VALUE)
 				splitIECLines = nValue;
+		}
+		else if (strcasecmp(pOption, "ignoreReset") == 0)
+		{
+			unsigned nValue = 0;
+			if ((nValue = GetDecimal(pValue)) != INVALID_VALUE)
+				ignoreReset = nValue;
 		}
 		else if ((strcasecmp(pOption, "Font") == 0))
 		{

--- a/src/options.h
+++ b/src/options.h
@@ -58,6 +58,8 @@ public:
 	unsigned int SoundOnGPIO() const { return soundOnGPIO; }
 	unsigned int SplitIECLines() const { return splitIECLines; }
 	unsigned int InvertIECInputs() const { return invertIECInputs; }
+	unsigned int InvertIECOutputs() const { return invertIECOutputs; }
+	unsigned int IgnoreReset() const { return ignoreReset; }
 
 	static unsigned GetDecimal(char* pString);
 
@@ -72,7 +74,9 @@ private:
 	unsigned int displayPNGIcons;
 	unsigned int soundOnGPIO;
 	unsigned int invertIECInputs;
+	unsigned int invertIECOutputs;
 	unsigned int splitIECLines;
+	unsigned int ignoreReset;
 
 	char ROMFontName[256];
 	char ROMName[256];

--- a/src/rpi-mailbox-interface.c
+++ b/src/rpi-mailbox-interface.c
@@ -39,6 +39,8 @@ void RPI_PropertyAddTag( rpi_mailbox_tag_t tag, ... )
 {
 	int* ptr;
 	int value;
+	int index;
+
     va_list vl;
     va_start( vl, tag );
 
@@ -197,7 +199,7 @@ void RPI_PropertyAddTag( rpi_mailbox_tag_t tag, ... )
 			ptr++;
 			pt[pt_index++] = value;
 			{
-				for (int index = 0; index < value; ++index)
+				for (index = 0; index < value; ++index)
 				{
 					pt[pt_index++] = *ptr++;
 				}


### PR DESCRIPTION
This PR adds two new options: `invertIECOutputs` to disable output signals inversion for non-inverting ICs like 7407 (default: true), and `ignoreReset` to ignore `/RESET` line state if it's not connected (default: false). Also fixes `Makefile.rules` to eagerly evaluate `$(CFLAGS)` so they won't mix up with `$(CPPFLAGS)` afterwards.