### PR TITLE
Add i2cLcdAddress option

### DIFF
--- a/src/ScreenLCD.cpp
+++ b/src/ScreenLCD.cpp
@@ -22,7 +22,7 @@
 #include <stdio.h>
 #include "debug.h"
 
-void ScreenLCD::Open(u32 widthDesired, u32 heightDesired, u32 colourDepth, int BSCMaster)
+void ScreenLCD::Open(u32 widthDesired, u32 heightDesired, u32 colourDepth, int BSCMaster, int LCDAddress)
 {
 	bpp = 1;
 
@@ -38,7 +38,7 @@ void ScreenLCD::Open(u32 widthDesired, u32 heightDesired, u32 colourDepth, int B
 	width = widthDesired;
 	height = heightDesired;
 
-	ssd1306 = new SSD1306(BSCMaster);
+	ssd1306 = new SSD1306(BSCMaster, LCDAddress);
 	ssd1306->DisplayOn();
 	ssd1306->Plottext(5, 1, "Pi1541", false);
 	ssd1306->RefreshScreen();

--- a/src/ScreenLCD.h
+++ b/src/ScreenLCD.h
@@ -32,7 +32,7 @@ public:
 	{
 	}
 
-	void Open(u32 width, u32 height, u32 colourDepth, int BSCMaster);
+	void Open(u32 width, u32 height, u32 colourDepth, int BSCMaster, int LCDAddress);
 
 	void ClearArea(u32 x1, u32 y1, u32 x2, u32 y2, RGBA colour);
 	void Clear(RGBA colour);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1020,6 +1020,8 @@ static void CheckOptions()
 		screen.PrintText(false, 0, y_pos+=16, tempBuffer, COLOUR_WHITE, COLOUR_BLACK);
 		snprintf(tempBuffer, tempBufferSize, "invertIECOutputs = %d\r\n", options.InvertIECOutputs());
 		screen.PrintText(false, 0, y_pos+=16, tempBuffer, COLOUR_WHITE, COLOUR_BLACK);
+		snprintf(tempBuffer, tempBufferSize, "i2cBusAddress = %d\r\n", options.I2CLcdAddress());
+		screen.PrintText(false, 0, y_pos+=16, tempBuffer, COLOUR_WHITE, COLOUR_BLACK);
 		IEC_Bus::WaitMicroSeconds(5 * 1000000);
 	}
 
@@ -1158,10 +1160,11 @@ extern "C"
 
 
 		int i2cBusMaster = options.I2CBusMaster();
+		int i2cLcdAddress = options.I2CLcdAddress();
 		if (strcasecmp(options.GetLCDName(), "ssd1306_128x64") == 0)
 		{
 			screenLCD = new ScreenLCD();
-			screenLCD->Open(128, 64, 1, i2cBusMaster);
+			screenLCD->Open(128, 64, 1, i2cBusMaster, i2cLcdAddress);
 		}
 		else
 		{

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -136,6 +136,7 @@ Options::Options(void)
 	, screenWidth(1024)
 	, screenHeight(768)
 	, i2cBusMaster(1)
+	, i2cLcdAddress(0x3C)
 	, keyboardBrowseLCDScreen(0)
 {
 	strcpy(ROMFontName, "chargen");
@@ -189,6 +190,7 @@ void Options::Process(char* buffer)
 		ELSE_CHECK_DECIMAL_OPTION(screenWidth)
 		ELSE_CHECK_DECIMAL_OPTION(screenHeight)
 		ELSE_CHECK_DECIMAL_OPTION(i2cBusMaster)
+		ELSE_CHECK_DECIMAL_OPTION(i2cLcdAddress)
 		ELSE_CHECK_DECIMAL_OPTION(keyboardBrowseLCDScreen)
 		else if ((strcasecmp(pOption, "StarFileName") == 0))
 		{

--- a/src/options.h
+++ b/src/options.h
@@ -65,7 +65,9 @@ public:
 
 	inline unsigned int ScreenWidth() const { return screenWidth; }
 	inline unsigned int ScreenHeight() const { return screenHeight; }
+
 	inline unsigned int I2CBusMaster() const { return i2cBusMaster; }
+	inline unsigned int I2CLcdAddress() const { return i2cLcdAddress; }
 
 	// Page up and down will jump a different amount based on the maximum number rows displayed.
 	// Perhaps we should use some keyboard modifier to the the other screen?
@@ -95,6 +97,7 @@ private:
 	unsigned int screenHeight;
 
 	unsigned int i2cBusMaster;
+	unsigned int i2cLcdAddress;
 
 	unsigned int keyboardBrowseLCDScreen;
 


### PR DESCRIPTION
i2cLcdAddress = 60

Note, this is in decimal and is "pre" shifting to the left.
60 decimal = 0x3c will drive an oled module set to "0x78"
61 decimal = 0x3d will drive an oled module set to "0x7a"