### PR TITLE
Change drive number with keyboard. Alt-N to create new D64 image with auto incremented name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.img
 *.lst
 *.map
+*.swp
+

--- a/options.txt
+++ b/options.txt
@@ -53,6 +53,11 @@ GraphIEC = 1
 // If you would like to specify what file will be loaded by LOAD"*" in browse mode then specify it here
 //StarFileName = somefile
 
+// Alt-N creates a new diskimage.
+// Names are formed automatically as autoname001.d64, autoname002.d64 etc...
+// change the base of the filename here
+//AutoBaseName = autoname
+
 // If you are using a LCD screen then specify it here
 //LCDName = ssd1306_128x64
 // If you are using a LCD screen and you would like PageUp and PageDown keys to work with it then specify this option
@@ -60,6 +65,8 @@ GraphIEC = 1
 
 // change startup logo on oled - 1541ii or 1541classic
 //LcdLogoName = 1541ii
+//LcdLogoName = 1541classic
+//LcdLogoName = customfile.raw
 
 // If you are using I2C LCD you can optionally change what pins it is connected to.
 // (defaults to 0 for non-split lines (Option A) or 1 for split lines (Option B))
@@ -68,6 +75,7 @@ GraphIEC = 1
 //i2cLcdAddress = 60	// I2C display address in decimal and shifted. 60 == 0x78, 61 == 0x7A
 //i2cLcdFlip = 1 // Rotate i2c LCD screen 180 degrees
 //i2cLcdOnContrast = 127 // Allows you to adjust the contrast on your i2c LCD screen
+//i2cScan = 1 // scan i2c bus and display addresses on screen
 
 //QuickBoot = 0		// faster startup
 //ShowOptions = 0	// display some options on startup screen 

--- a/src/FileBrowser.cpp
+++ b/src/FileBrowser.cpp
@@ -32,6 +32,9 @@ extern "C"
 #include "rpi-gpio.h"
 }
 
+#include "iec_commands.h"
+extern IEC_Commands m_IEC_Commands;
+
 #define PNG_WIDTH 320
 #define PNG_HEIGHT 200
 
@@ -892,6 +895,14 @@ void FileBrowser::UpdateInputFolders()
 				dirty = AddToCaddy(current);
 			}
 		}
+		else if (inputMappings->BrowseNewD64())
+		{
+			char newFileName[64];
+			int num = folder.FindNextAutoName("testfile");
+			snprintf(newFileName, 64, "testfile%03d.d64", num);
+			m_IEC_Commands.CreateD64(newFileName, "42");
+			FolderChanged();
+		}
 		else
 		{
 			unsigned keySetIndex;
@@ -1240,4 +1251,22 @@ void FileBrowser::AutoSelectImage(const char* image)
 		caddySelections.entries.push_back(*current);
 		selectionsMade = FillCaddyWithSelections();
 	}
+}
+
+int FileBrowser::BrowsableList::FindNextAutoName(const char* basename)
+{
+	int index;
+	int len = (int)entries.size();
+	int baselen = strlen(basename);
+	int lastNumber = 0;
+
+	for (index = 0; index < len; ++index)
+	{
+		Entry* entry = &entries[index];
+		if (!(entry->filImage.fattrib & AM_DIR) && strncasecmp(basename, entry->filImage.fname, baselen) == 0)
+		{
+			lastNumber = 55;
+		}
+	}
+	return lastNumber+1;
 }

--- a/src/FileBrowser.cpp
+++ b/src/FileBrowser.cpp
@@ -34,6 +34,8 @@ extern "C"
 
 #include "iec_commands.h"
 extern IEC_Commands m_IEC_Commands;
+extern Options options;
+
 
 #define PNG_WIDTH 320
 #define PNG_HEIGHT 200
@@ -898,8 +900,8 @@ void FileBrowser::UpdateInputFolders()
 		else if (inputMappings->BrowseNewD64())
 		{
 			char newFileName[64];
-			int num = folder.FindNextAutoName("testfile");
-			snprintf(newFileName, 64, "testfile%03d.d64", num);
+			strncpy (newFileName, options.GetAutoBaseName(), 63);
+			int num = folder.FindNextAutoName( newFileName );
 			m_IEC_Commands.CreateD64(newFileName, "42");
 			FolderChanged();
 		}
@@ -1253,16 +1255,17 @@ void FileBrowser::AutoSelectImage(const char* image)
 	}
 }
 
-int FileBrowser::BrowsableList::FindNextAutoName(const char* basename)
+int FileBrowser::BrowsableList::FindNextAutoName(char* filename)
 {
 	int index;
 	int len = (int)entries.size();
-	int baselen = strlen(basename);
-	int lastNumber = 0;
-	char matchname[64];
 
-	strcpy (matchname, basename);
-	strncat (matchname, "%d",2);
+	int inputlen = strlen(filename);
+	int lastNumber = 0;
+
+	char scanfname[64];
+	strncpy (scanfname, filename, 54);
+	strncat (scanfname, "%d",2);
 
 	int foundnumber;
 
@@ -1270,13 +1273,14 @@ int FileBrowser::BrowsableList::FindNextAutoName(const char* basename)
 	{
 		Entry* entry = &entries[index];
 		if (	!(entry->filImage.fattrib & AM_DIR) 
-			&& strncasecmp(basename, entry->filImage.fname, baselen) == 0
-			&& sscanf(entry->filImage.fname, matchname, &foundnumber) == 1
+			&& strncasecmp(filename, entry->filImage.fname, inputlen) == 0
+			&& sscanf(entry->filImage.fname, scanfname, &foundnumber) == 1
 			)
 		{
 			if (foundnumber > lastNumber)
 				lastNumber = foundnumber;
 		}
 	}
+	snprintf(filename + inputlen, 54, "%03d.d64", lastNumber+1);
 	return lastNumber+1;
 }

--- a/src/FileBrowser.cpp
+++ b/src/FileBrowser.cpp
@@ -1259,13 +1259,23 @@ int FileBrowser::BrowsableList::FindNextAutoName(const char* basename)
 	int len = (int)entries.size();
 	int baselen = strlen(basename);
 	int lastNumber = 0;
+	char matchname[64];
+
+	strcpy (matchname, basename);
+	strncat (matchname, "%d",2);
+
+	int foundnumber;
 
 	for (index = 0; index < len; ++index)
 	{
 		Entry* entry = &entries[index];
-		if (!(entry->filImage.fattrib & AM_DIR) && strncasecmp(basename, entry->filImage.fname, baselen) == 0)
+		if (	!(entry->filImage.fattrib & AM_DIR) 
+			&& strncasecmp(basename, entry->filImage.fname, baselen) == 0
+			&& sscanf(entry->filImage.fname, matchname, &foundnumber) == 1
+			)
 		{
-			lastNumber = 55;
+			if (foundnumber > lastNumber)
+				lastNumber = foundnumber;
 		}
 	}
 	return lastNumber+1;

--- a/src/FileBrowser.cpp
+++ b/src/FileBrowser.cpp
@@ -902,7 +902,7 @@ void FileBrowser::UpdateInputFolders()
 			char newFileName[64];
 			strncpy (newFileName, options.GetAutoBaseName(), 63);
 			int num = folder.FindNextAutoName( newFileName );
-			m_IEC_Commands.CreateD64(newFileName, "42");
+			m_IEC_Commands.CreateD64(newFileName, "42", true);
 			FolderChanged();
 		}
 		else

--- a/src/FileBrowser.h
+++ b/src/FileBrowser.h
@@ -151,7 +151,7 @@ public:
 		};
 
 		Entry* FindEntry(const char* name);
-		int FindNextAutoName(const char* basename);
+		int FindNextAutoName(char* basename);
 
 		void RefreshViews();
 		void RefreshViewsHighlightScroll();

--- a/src/FileBrowser.h
+++ b/src/FileBrowser.h
@@ -151,6 +151,7 @@ public:
 		};
 
 		Entry* FindEntry(const char* name);
+		int FindNextAutoName(const char* basename);
 
 		void RefreshViews();
 		void RefreshViewsHighlightScroll();

--- a/src/FileBrowser.h
+++ b/src/FileBrowser.h
@@ -166,7 +166,7 @@ public:
 		std::vector<BrowsableListView> views;
 	};
 
-	FileBrowser(DiskCaddy* diskCaddy, ROMs* roms, unsigned deviceID, bool displayPNGIcons, ScreenBase* screenMain, ScreenBase* screenLCD, float scrollHighlightRate);
+	FileBrowser(DiskCaddy* diskCaddy, ROMs* roms, u8* deviceID, bool displayPNGIcons, ScreenBase* screenMain, ScreenBase* screenLCD, float scrollHighlightRate);
 
 	void AutoSelectImage(const char* image);
 	void DisplayRoot();
@@ -187,8 +187,6 @@ public:
 	void ShowDeviceAndROM();
 
 	void ClearScreen();
-
-	void SetDeviceID(u8 id) { deviceID = id; }
 
 	static const long int LSTBuffer_size = 1024 * 8;
 	static unsigned char LSTBuffer[];
@@ -230,7 +228,7 @@ private:
 	bool selectionsMade;
 	const char* lastSelectionName;
 	ROMs* roms;
-	unsigned deviceID;
+	u8* deviceID;
 	bool displayPNGIcons;
 
 	BrowsableList caddySelections;

--- a/src/InputMappings.cpp
+++ b/src/InputMappings.cpp
@@ -170,7 +170,7 @@ bool InputMappings::CheckKeyboardBrowseMode()
 	//	SetKeyboardFlag(PAGEUP_LCD_FLAG);
 	//else if (keyboard->KeyHeld(KEY_END))
 	//	SetKeyboardFlag(PAGEDOWN_LCD_FLAG);
-	else if (keyboard->KeyHeld(KEY_N))
+	else if (keyboard->KeyHeld(KEY_N) && keyboard->KeyEitherAlt() )
 		SetKeyboardFlag(NEWD64_FLAG);
 	else
 	{

--- a/src/InputMappings.cpp
+++ b/src/InputMappings.cpp
@@ -170,6 +170,8 @@ bool InputMappings::CheckKeyboardBrowseMode()
 	//	SetKeyboardFlag(PAGEUP_LCD_FLAG);
 	//else if (keyboard->KeyHeld(KEY_END))
 	//	SetKeyboardFlag(PAGEDOWN_LCD_FLAG);
+	else if (keyboard->KeyHeld(KEY_N))
+		SetKeyboardFlag(NEWD64_FLAG);
 	else
 	{
 		unsigned index;

--- a/src/InputMappings.cpp
+++ b/src/InputMappings.cpp
@@ -175,7 +175,7 @@ bool InputMappings::CheckKeyboardBrowseMode()
 	else
 	{
 		unsigned index;
-		for (index = 0; index < 10; ++index)
+		for (index = 0; index < 11; ++index)
 		{
 			unsigned keySetIndexBase = index * 3;
 			if (keyboard->KeyHeld(FileBrowser::SwapKeys[keySetIndexBase]) || keyboard->KeyHeld(FileBrowser::SwapKeys[keySetIndexBase + 1]) || keyboard->KeyHeld(FileBrowser::SwapKeys[keySetIndexBase + 2]))

--- a/src/InputMappings.h
+++ b/src/InputMappings.h
@@ -28,14 +28,17 @@
 #define UP_FLAG			(1 << 4)
 #define PAGEUP_FLAG		(1 << 5)
 #define DOWN_FLAG		(1 << 6)
-#define PAGEDOWN_FLAG	(1 << 7)
+#define PAGEDOWN_FLAG		(1 << 7)
 #define SPACE_FLAG		(1 << 8)
 #define BACK_FLAG		(1 << 9)
 #define INSERT_FLAG		(1 << 10)
 #define NUMBER_FLAG		(1 << 11)
 
-#define PAGEDOWN_LCD_FLAG (1 << 12)
-#define PAGEUP_LCD_FLAG (1 << 13)
+#define PAGEDOWN_LCD_FLAG	(1 << 12)
+#define PAGEUP_LCD_FLAG		(1 << 13)
+
+#define NEWD64_FLAG		(1 << 14)
+// dont exceed 32!!
 
 class InputMappings : public Singleton<InputMappings>
 {
@@ -135,6 +138,11 @@ public:
 	inline bool BrowseInsert()
 	{
 		return KeyboardFlag(INSERT_FLAG)/* | UartFlag(INSERT_FLAG)*/ | ButtonFlag(INSERT_FLAG);
+	}
+
+	inline bool BrowseNewD64()
+	{
+		return KeyboardFlag(NEWD64_FLAG);
 	}
 
 	// Used by the 2 cores so need to be volatile

--- a/src/Keyboard.h
+++ b/src/Keyboard.h
@@ -344,9 +344,9 @@ public:
 	{
 		return (keyStatus[0] | keyStatus[1]);
 	}
-	inline bool KeyLeftAlt()
+	inline bool KeyEitherAlt()
 	{
-		return (modifier & 1<<2);
+		return (modifier & (KEY_MOD_LALT | KEY_MOD_RALT) );
 	}
 };
 #endif

--- a/src/Keyboard.h
+++ b/src/Keyboard.h
@@ -344,5 +344,9 @@ public:
 	{
 		return (keyStatus[0] | keyStatus[1]);
 	}
+	inline bool KeyLeftAlt()
+	{
+		return (modifier & 1<<2);
+	}
 };
 #endif

--- a/src/ROMs.h
+++ b/src/ROMs.h
@@ -34,7 +34,7 @@ public:
 	void ResetCurrentROMIndex();
 
 	static const int ROM_SIZE = 16384;
-	static const int MAX_ROMS = 8;
+	static const int MAX_ROMS = 7;
 
 	unsigned char ROMImages[MAX_ROMS][ROM_SIZE];
 	char ROMNames[MAX_ROMS][256];

--- a/src/iec_commands.cpp
+++ b/src/iec_commands.cpp
@@ -1103,23 +1103,12 @@ void IEC_Commands::New(void)
 		if(!(strstr(filenameNew, ".d64") || strstr(filenameNew, ".D64")))
 			strcat(filenameNew, ".d64");
 
-		int ret = CreateD64(filenameNew, ID);
+		int ret = CreateD64(filenameNew, ID, true);
 
 		if (ret==0)
-		{
 			updateAction = REFRESH;
-
-			// Mount the new disk? Shoud we do this or let them do it manually?
-			if (f_stat(filenameNew, &filInfo) == FR_OK)
-			{
-				DIR dir;
-				Enter(dir, filInfo);
-			}
-		}
 		else
-		{
 			Error(ret);
-		}
 	}
 }
 
@@ -1884,7 +1873,7 @@ void IEC_Commands::CloseFile(u8 secondary)
 	channel.Close();
 }
 
-int IEC_Commands::CreateD64(char* filenameNew, char* ID)
+int IEC_Commands::CreateD64(char* filenameNew, char* ID, bool automount)
 {
 	FILINFO filInfo;
 	FRESULT res;
@@ -1940,6 +1929,12 @@ int IEC_Commands::CreateD64(char* filenameNew, char* ID)
 					break;
 			}
 			f_close(&fpOut);
+		}
+		// Mount the new disk? Shoud we do this or let them do it manually?
+		if (automount && f_stat(filenameNew, &filInfo) == FR_OK)
+		{
+			DIR dir;
+			Enter(dir, filInfo);
 		}
 		return(ERROR_00_OK);
 	}

--- a/src/iec_commands.cpp
+++ b/src/iec_commands.cpp
@@ -1107,6 +1107,8 @@ void IEC_Commands::New(void)
 
 		if (ret==0)
 		{
+			updateAction = REFRESH;
+
 			// Mount the new disk? Shoud we do this or let them do it manually?
 			if (f_stat(filenameNew, &filInfo) == FR_OK)
 			{
@@ -1187,6 +1189,7 @@ void IEC_Commands::Scratch(void)
 				f_unlink(filInfo.fname);
 			}
 			res = f_findnext(&dir, &filInfo);
+			updateAction = REFRESH;
 		}
 		text = ParseNextName(text, filename, true);
 	}

--- a/src/iec_commands.cpp
+++ b/src/iec_commands.cpp
@@ -1099,70 +1099,24 @@ void IEC_Commands::New(void)
 	if (ParseFilenames((char*)channel.buffer, filenameNew, ID))
 	{
 		FILINFO filInfo;
-		FRESULT res;
-		char* ptr;
-		int i;
-		//bool g64 = false;
 
-		//if (strstr(filenameNew, ".g64") || strstr(filenameNew, ".G64"))
-		//	g64 = true;
-		//else 
 		if(!(strstr(filenameNew, ".d64") || strstr(filenameNew, ".D64")))
 			strcat(filenameNew, ".d64");
 
-		res = f_stat(filenameNew, &filInfo);
-		if (res == FR_NO_FILE)
-		{
-			FIL fpOut;
-			res = f_open(&fpOut, filenameNew, FA_CREATE_ALWAYS | FA_WRITE);
-			if (res == FR_OK)
-			{
-				char buffer[256];
-				u32 bytes;
-				u32 blocks;
+		int ret = CreateD64(filenameNew, ID);
 
-				memset(buffer, 0, sizeof(buffer));
-				// TODO: Should check for disk full.
-				for (blocks = 0; blocks < 357; ++blocks)
-				{
-					if (f_write(&fpOut, buffer, 256, &bytes) != FR_OK)
-						break;
-				}
-				ptr = (char*)&blankD64DIRBAM[DISKNAME_OFFSET_IN_DIR_BLOCK];
-				int len = strlen(filenameNew);
-				for (i = 0; i < len; ++i)
-				{
-					*ptr++ = ascii2petscii(filenameNew[i]);
-				}
-				for (; i < 18; ++i)
-				{
-					*ptr++ = 0xa0;
-				}
-				for (i = 0; i < 2; ++i)
-				{
-					*ptr++ = ascii2petscii(ID[i]);
-				}
-				f_write(&fpOut, blankD64DIRBAM, 256, &bytes);
-				buffer[1] = 0xff;
-				f_write(&fpOut, buffer, 256, &bytes);
-				buffer[1] = 0;
-				for (blocks = 0; blocks < 324; ++blocks)
-				{
-					if (f_write(&fpOut, buffer, 256, &bytes) != FR_OK)
-						break;
-				}
-				f_close(&fpOut);
-				// Mount the new disk? Shoud we do this or let them do it manually?
-				if (f_stat(filenameNew, &filInfo) == FR_OK)
-				{
-					DIR dir;
-					Enter(dir, filInfo);
-				}
+		if (ret==0)
+		{
+			// Mount the new disk? Shoud we do this or let them do it manually?
+			if (f_stat(filenameNew, &filInfo) == FR_OK)
+			{
+				DIR dir;
+				Enter(dir, filInfo);
 			}
 		}
 		else
 		{
-			Error(ERROR_63_FILE_EXISTS);
+			Error(ret);
 		}
 	}
 }
@@ -1925,4 +1879,69 @@ void IEC_Commands::CloseFile(u8 secondary)
 	Channel& channel = channels[secondary];
 
 	channel.Close();
+}
+
+int IEC_Commands::CreateD64(char* filenameNew, char* ID)
+{
+	FILINFO filInfo;
+	FRESULT res;
+	char* ptr;
+	int i;
+	//bool g64 = false;
+
+	//if (strstr(filenameNew, ".g64") || strstr(filenameNew, ".G64"))
+	//	g64 = true;
+	//else
+	if(!(strstr(filenameNew, ".d64") || strstr(filenameNew, ".D64")))
+		strcat(filenameNew, ".d64");
+
+	res = f_stat(filenameNew, &filInfo);
+	if (res == FR_NO_FILE)
+	{
+		FIL fpOut;
+		res = f_open(&fpOut, filenameNew, FA_CREATE_ALWAYS | FA_WRITE);
+		if (res == FR_OK)
+		{
+			char buffer[256];
+			u32 bytes;
+			u32 blocks;
+
+			memset(buffer, 0, sizeof(buffer));
+			// TODO: Should check for disk full.
+			for (blocks = 0; blocks < 357; ++blocks)
+			{
+				if (f_write(&fpOut, buffer, 256, &bytes) != FR_OK)
+					break;
+			}
+			ptr = (char*)&blankD64DIRBAM[DISKNAME_OFFSET_IN_DIR_BLOCK];
+			int len = strlen(filenameNew);
+			for (i = 0; i < len; ++i)
+			{
+				*ptr++ = ascii2petscii(filenameNew[i]);
+			}
+			for (; i < 18; ++i)
+			{
+				*ptr++ = 0xa0;
+			}
+			for (i = 0; i < 2; ++i)
+			{
+				*ptr++ = ascii2petscii(ID[i]);
+			}
+			f_write(&fpOut, blankD64DIRBAM, 256, &bytes);
+			buffer[1] = 0xff;
+			f_write(&fpOut, buffer, 256, &bytes);
+			buffer[1] = 0;
+			for (blocks = 0; blocks < 324; ++blocks)
+			{
+				if (f_write(&fpOut, buffer, 256, &bytes) != FR_OK)
+					break;
+			}
+			f_close(&fpOut);
+		}
+		return(ERROR_00_OK);
+	}
+	else
+	{
+		return(ERROR_63_FILE_EXISTS);
+	}
 }

--- a/src/iec_commands.h
+++ b/src/iec_commands.h
@@ -79,7 +79,7 @@ public:
 	const FILINFO* GetImageSelected() const { return &filInfoSelectedImage; }
 	void SetStarFileName(const char* fileName) { starFileName = fileName; }
 
-	int CreateD64(char* filenameNew, char* ID);
+	int CreateD64(char* filenameNew, char* ID, bool automount);
 
 protected:
 	enum ATNSequence 

--- a/src/iec_commands.h
+++ b/src/iec_commands.h
@@ -78,6 +78,9 @@ public:
 	const char* GetNameOfImageSelected() const { return selectedImageName; }
 	const FILINFO* GetImageSelected() const { return &filInfoSelectedImage; }
 	void SetStarFileName(const char* fileName) { starFileName = fileName; }
+
+	int CreateD64(char* filenameNew, char* ID);
+
 protected:
 	enum ATNSequence 
 	{
@@ -128,7 +131,6 @@ protected:
 	void CloseAllChannels();
 	void SendError();
 
-	int CreateD64(char* filenameNew, char* ID);
 
 	bool Enter(DIR& dir, FILINFO& filInfo);
 	bool FindFirst(DIR& dir, const char* matchstr, FILINFO& filInfo);

--- a/src/iec_commands.h
+++ b/src/iec_commands.h
@@ -128,6 +128,8 @@ protected:
 	void CloseAllChannels();
 	void SendError();
 
+	int CreateD64(char* filenameNew, char* ID);
+
 	bool Enter(DIR& dir, FILINFO& filInfo);
 	bool FindFirst(DIR& dir, const char* matchstr, FILINFO& filInfo);
 
@@ -169,3 +171,4 @@ protected:
 	const char* starFileName;
 };
 #endif
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -697,8 +697,10 @@ void emulator()
 			fileBrowser->ClearSelections();
 
 			// Go back to the root folder so you can load fb* again?
-			if ((resetWhileEmulating && options.GetOnResetChangeToStartingFolder()) || selectedViaIECCommands) fileBrowser->DisplayRoot(); // Go back to the root folder and display it.
-			else fileBrowser->RefeshDisplay(); // Just redisplay the current folder.
+//			if ((resetWhileEmulating && options.GetOnResetChangeToStartingFolder()) || selectedViaIECCommands)
+//				fileBrowser->DisplayRoot(); // Go back to the root folder and display it.
+//			else
+				fileBrowser->RefeshDisplay(); // Just redisplay the current folder.
 
 			resetWhileEmulating = false;
 			selectedViaIECCommands = false;
@@ -979,12 +981,14 @@ void emulator()
 
 					IEC_Bus::WaitUntilReset();
 					//DEBUG_LOG("6502 resetting\r\n");
-					if (options.GetOnResetChangeToStartingFolder() || selectedViaIECCommands)
-						fileBrowser->DisplayRoot();//m_IEC_Commands.ChangeToRoot(); // TO CHECK
 					emulating = false;
 					resetWhileEmulating = true;
 					if (reset)
+					{
 						exitReason = EXIT_RESET;
+						if (options.GetOnResetChangeToStartingFolder() || selectedViaIECCommands)
+							fileBrowser->DisplayRoot(); // TO CHECK
+					}
 					if (exitEmulation)
 						exitReason = EXIT_KEYBOARD;
 					break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -639,8 +639,15 @@ static void PlaySoundDMA()
 
 static void SetVIAsDeviceID(u8 id)
 {
-	if (id & 1) pi1541.VIA[0].GetPortB()->SetInput(VIAPORTPINS_DEVSEL0, true);
-	if (id & 2) pi1541.VIA[0].GetPortB()->SetInput(VIAPORTPINS_DEVSEL1, true);
+	pi1541.VIA[0].GetPortB()->SetInput(VIAPORTPINS_DEVSEL0, id & 1);
+	pi1541.VIA[0].GetPortB()->SetInput(VIAPORTPINS_DEVSEL1, id & 2);
+}
+
+void GlobalSetDeviceID(u8 id)
+{
+	deviceID = id;
+	m_IEC_Commands.SetDeviceId(id);
+	SetVIAsDeviceID(id);
 }
 
 static void CheckAutoMountImage(EXIT_TYPE reset_reason , FileBrowser* fileBrowser)
@@ -677,7 +684,7 @@ void emulator()
 	roms.lastManualSelectedROMIndex = 0;
 
 	diskCaddy.SetScreen(&screen, screenLCD);
-	fileBrowser = new FileBrowser(&diskCaddy, &roms, deviceID, options.DisplayPNGIcons(), &screen, screenLCD, options.ScrollHighlightRate());
+	fileBrowser = new FileBrowser(&diskCaddy, &roms, &deviceID, options.DisplayPNGIcons(), &screen, screenLCD, options.ScrollHighlightRate());
 	fileBrowser->DisplayRoot();
 	pi1541.Initialise();
 
@@ -790,8 +797,7 @@ void emulator()
 							fileBrowser->FolderChanged();
 							break;
 						case IEC_Commands::DEVICEID_CHANGED:
-							deviceID = m_IEC_Commands.GetDeviceId();
-							fileBrowser->SetDeviceID(deviceID);
+							GlobalSetDeviceID( m_IEC_Commands.GetDeviceId() );
 							fileBrowser->ShowDeviceAndROM();
 							SetVIAsDeviceID(deviceID);	// Let the emulated VIA know
 							break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1129,6 +1129,8 @@ void DisplayOptions(int y_pos)
 	screen.PrintText(false, 0, y_pos += 16, tempBuffer, COLOUR_WHITE, COLOUR_BLACK);
 	snprintf(tempBuffer, tempBufferSize, "LcdLogoName = %s\r\n", options.GetLcdLogoName());
 	screen.PrintText(false, 0, y_pos += 16, tempBuffer, COLOUR_WHITE, COLOUR_BLACK);
+	snprintf(tempBuffer, tempBufferSize, "AutoBaseName = %s\r\n", options.GetAutoBaseName());
+	screen.PrintText(false, 0, y_pos += 16, tempBuffer, COLOUR_WHITE, COLOUR_BLACK);
 }
 
 void DisplayI2CScan(int y_pos)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -793,7 +793,7 @@ void emulator()
 							deviceID = m_IEC_Commands.GetDeviceId();
 							fileBrowser->SetDeviceID(deviceID);
 							fileBrowser->ShowDeviceAndROM();
-							SetVIAsDeviceID(deviceID);	// Let the emilated VIA know
+							SetVIAsDeviceID(deviceID);	// Let the emulated VIA know
 							break;
 						default:
 							break;
@@ -1361,3 +1361,4 @@ extern "C"
 #endif
 	}
 }
+

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -152,6 +152,7 @@ Options::Options(void)
 	autoMountImageName[0] = 0;
 	strcpy(ROMFontName, "chargen");
 	strcpy(LcdLogoName, "1541ii");
+	strcpy(autoBaseName, "autoname");
 	starFileName[0] = 0;
 	ROMName[0] = 0;
 	ROMNameSlot2[0] = 0;
@@ -224,6 +225,10 @@ void Options::Process(char* buffer)
 		ELSE_CHECK_DECIMAL_OPTION(i2cLcdDimTime)
 		ELSE_CHECK_FLOAT_OPTION(scrollHighlightRate)
 		ELSE_CHECK_DECIMAL_OPTION(keyboardBrowseLCDScreen)
+		else if ((strcasecmp(pOption, "AutoBaseName") == 0))
+		{
+			strncpy(autoBaseName, pValue, 255);
+		}
 		else if ((strcasecmp(pOption, "StarFileName") == 0))
 		{
 			strncpy(starFileName, pValue, 255);

--- a/src/options.h
+++ b/src/options.h
@@ -89,6 +89,8 @@ public:
 
 	const char* GetLCDName() const { return LCDName; }
 
+	const char* GetAutoBaseName() const { return autoBaseName; }
+
 	static unsigned GetDecimal(char* pString);
 	static float GetFloat(char* pString);
 
@@ -128,6 +130,7 @@ private:
 	unsigned int keyboardBrowseLCDScreen;
 
 	char starFileName[256];
+	char autoBaseName[256];
 	char LCDName[256];
 	char LcdLogoName[256];
 


### PR DESCRIPTION
And then automount it as described in #43 

Names are created based on AutoBaseName option In options.txt.
`AutoBaseName = autoname`
Will create autoname001.d64 and then autoname002.d64. It searches the current dir to find the highest existing filename and then adds 1.

Can now change device ID in browse mode with keyboard 8,9,0,- and F8...F11
Maximum rom images is now 7 (down from 8)

Also fixes @S:0 and @N:0 commands to autorefresh the file list