### PR TITLE
overwrite longer rom names on screen

### DIFF
--- a/src/DiskCaddy.cpp
+++ b/src/DiskCaddy.cpp
@@ -292,7 +292,11 @@ void DiskCaddy::ShowSelectedImage(u32 index)
 		x = 0;
 		y = 0;
 
-		snprintf(buffer, 256, "        D %d/%d           ", index + 1, numberOfImages);
+		snprintf(buffer, 256, "        D %d/%d %c        "
+			, index + 1
+			, numberOfImages
+			, GetImage(index)->GetReadOnly() ? 'R' : ' '
+			);
 		screenLCD->PrintText(false, x, y, buffer, RGBA(0xff, 0xff, 0xff, 0xff), RGBA(0xff, 0xff, 0xff, 0xff));
 		y += LCDFONTHEIGHT;
 

--- a/src/FileBrowser.cpp
+++ b/src/FileBrowser.cpp
@@ -1153,7 +1153,11 @@ void FileBrowser::ShowDeviceAndROM()
 	u32 x = 0; // 43 * 8
 	u32 y = screenMain->ScaleY(STATUS_BAR_POSITION_Y) - 20;
 
-	snprintf(buffer, 256, "Device %2d %s\r\n", *deviceID, roms->ROMNames[roms->currentROMIndex]);
+	snprintf(buffer, 256, "Device %2d %*s\r\n"
+		, *deviceID
+		, roms->GetLongestRomNameLen()
+		, roms->ROMNames[roms->currentROMIndex]
+		);
 	screenMain->PrintText(false, x, y, buffer, textColour, bgColour);
 }
 

--- a/src/ROMs.cpp
+++ b/src/ROMs.cpp
@@ -43,3 +43,10 @@ void ROMs::SelectROM(const char* ROMName)
 	}
 }
 
+unsigned ROMs::UpdateLongestRomNameLen( unsigned maybeLongest )
+{
+	if (maybeLongest > longestRomNameLen)
+		longestRomNameLen = maybeLongest;
+
+	return longestRomNameLen;
+}

--- a/src/ROMs.h
+++ b/src/ROMs.h
@@ -42,5 +42,12 @@ public:
 
 	unsigned currentROMIndex;
 	unsigned lastManualSelectedROMIndex;
+
+	unsigned GetLongestRomNameLen() { return longestRomNameLen; }
+	unsigned UpdateLongestRomNameLen( unsigned maybeLongest );
+
+protected:
+	unsigned longestRomNameLen;
 };
+
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1240,6 +1240,7 @@ static void CheckOptions()
 				{
 					strncpy(roms.ROMNames[ROMIndex], ROMName, 255);
 					roms.ROMValid[ROMIndex] = true;
+					roms.UpdateLongestRomNameLen( strlen(roms.ROMNames[ROMIndex]) );
 				}
 				f_close(&fp);
 				//DEBUG_LOG("Read ROM %s from options\r\n", ROMName);


### PR DESCRIPTION
Fix issue reported on lemon64 and also show 'R' on oled for readonly images

[quote="Stefan Both"]I have a small error detected in the new firmware 1.10.
As already mentioned I use an HDMI Display (480X320).
I am able to switch between the files named "dos1541"
and "Jiffy. bin" forth and back. However if I switch from
Jiffy. bin back to dos1541, the last two letters of Jiffy. b [b]in[/b]
remain on the display. ( 7 vs. 9 letters)

Stefan[/quote]

