### PR TITLE
In browse, pressing a-z jumps to the next entry with matching 1st letter

### DIFF
--- a/src/FileBrowser.cpp
+++ b/src/FileBrowser.cpp
@@ -45,21 +45,6 @@ extern void CheckAutoMountImage(EXIT_TYPE reset_reason , FileBrowser* fileBrowse
 
 unsigned char FileBrowser::LSTBuffer[FileBrowser::LSTBuffer_size];
 
-const unsigned FileBrowser::SwapKeys[33] =
-{
-	KEY_F1, KEY_KP1, KEY_1,
-	KEY_F2, KEY_KP2, KEY_2,
-	KEY_F3, KEY_KP3, KEY_3,
-	KEY_F4, KEY_KP4, KEY_4,
-	KEY_F5, KEY_KP5, KEY_5,
-	KEY_F6, KEY_KP6, KEY_6,
-	KEY_F7, KEY_KP7, KEY_7,
-	KEY_F8, KEY_KP8, KEY_8,
-	KEY_F9, KEY_KP9, KEY_9,
-	KEY_F10, KEY_KP0, KEY_0,
-	KEY_F11, KEY_KPMINUS, KEY_MINUS
-};
-
 static const u32 palette[] = 
 {
 	RGBA(0x00, 0x00, 0x00, 0xFF),
@@ -375,6 +360,28 @@ FileBrowser::BrowsableList::Entry* FileBrowser::BrowsableList::FindEntry(const c
 		Entry* entry = &entries[index];
 		if (!(entry->filImage.fattrib & AM_DIR) && strcasecmp(name, entry->filImage.fname) == 0)
 			return entry;
+	}
+	return 0;
+}
+
+FileBrowser::BrowsableList::Entry* FileBrowser::BrowsableList::FindNextPartialEntry(const char* name, int match_len)
+{
+	int index;
+	int len = (int)entries.size();
+
+	for (index = 0; index < len; ++index)
+	{
+		Entry* entry = &entries[index];
+		if (match_len) // partial match
+		{
+			if (strncasecmp(name, entry->filImage.fname, match_len) == 0)
+				return entry;
+		}
+		else // full match
+		{
+			if (strcasecmp(name, entry->filImage.fname) == 0)
+				return entry;
+		}
 	}
 	return 0;
 }
@@ -980,14 +987,11 @@ void FileBrowser::UpdateInputFolders()
 			else
 			{
 				// check for number keys for ROM and Drive Number changes
-				unsigned keySetIndex;
-				for (keySetIndex = 0; keySetIndex < 11; ++keySetIndex)
+				if (inputMappings->BrowseNumber()
+					&& inputMappings->getKeyboardNumber() >= 0
+					&& inputMappings->getKeyboardNumber() < 11 )
 				{
-					unsigned keySetIndexBase = keySetIndex * 3;
-					if (keyboard->KeyPressed(FileBrowser::SwapKeys[keySetIndexBase]) 
-					|| keyboard->KeyPressed(FileBrowser::SwapKeys[keySetIndexBase + 1]) 
-					|| keyboard->KeyPressed(FileBrowser::SwapKeys[keySetIndexBase + 2]))
-						SelectROMOrDevice(keySetIndex);
+					SelectROMOrDevice(inputMappings->getKeyboardNumber());
 				}
 
 				// check for keys a-z

--- a/src/FileBrowser.cpp
+++ b/src/FileBrowser.cpp
@@ -308,46 +308,6 @@ bool FileBrowser::BrowsableListView::CheckBrowseNavigation(bool pageOnly)
 		dirty = true;
 	}
 
-	// check for keys a-z
-	if (inputMappings->BrowseLetter())
-	{
-		char temp[8];
-		unsigned found=0;
-		u32 i=0;
-		snprintf (temp, sizeof(temp), "%c", inputMappings->getKeyboardLetter());
-
-		// first look from next to last
-		for (i=1+list->currentIndex; i <= numberOfEntriesMinus1 ; i++)
-		{
-			FileBrowser::BrowsableList::Entry* entry = &list->entries[i];
-			if (strncasecmp(temp, entry->filImage.fname, 1) == 0)
-			{
-				found=i;
-				break;
-			}
-		}
-		if (!found)
-		{
-			// look from first to previous
-			for (i=0; i< 1+list->currentIndex ; i++)
-			{
-				FileBrowser::BrowsableList::Entry* entry = &list->entries[i];
-				if (strncasecmp(temp, entry->filImage.fname, 1) == 0)
-				{
-					found=i;
-					break;
-				}
-			}
-		}
-
-		if (found)
-		{
-			list->currentIndex=found;
-			list->SetCurrent();
-			dirty = true;
-		}
-	}
-
 	return dirty;
 }
 
@@ -381,12 +341,55 @@ void FileBrowser::BrowsableList::RefreshViewsHighlightScroll()
 
 bool FileBrowser::BrowsableList::CheckBrowseNavigation()
 {
+	InputMappings* inputMappings = InputMappings::Instance();
+	u32 numberOfEntriesMinus1 = entries.size() - 1;
+
 	bool dirty = false;
 	u32 index;
 	for (index = 0; index < views.size(); ++index)
 	{
 		dirty |= views[index].CheckBrowseNavigation(index != 0);
 	}
+	// check for keys a-z
+	if (inputMappings->BrowseLetter())
+	{
+		char temp[8];
+		unsigned found=0;
+		u32 i=0;
+		snprintf (temp, sizeof(temp), "%c", inputMappings->getKeyboardLetter());
+
+		// first look from next to last
+		for (i=1+currentIndex; i <= numberOfEntriesMinus1 ; i++)
+		{
+			FileBrowser::BrowsableList::Entry* entry = &entries[i];
+			if (strncasecmp(temp, entry->filImage.fname, 1) == 0)
+			{
+				found=i;
+				break;
+			}
+		}
+		if (!found)
+		{
+			// look from first to previous
+			for (i=0; i< 1+currentIndex ; i++)
+			{
+				FileBrowser::BrowsableList::Entry* entry = &entries[i];
+				if (strncasecmp(temp, entry->filImage.fname, 1) == 0)
+				{
+					found=i;
+					break;
+				}
+			}
+		}
+
+		if (found)
+		{
+			currentIndex=found;
+			SetCurrent();
+			dirty |= 1;
+		}
+	}
+
 	return dirty;
 }
 

--- a/src/FileBrowser.cpp
+++ b/src/FileBrowser.cpp
@@ -308,6 +308,46 @@ bool FileBrowser::BrowsableListView::CheckBrowseNavigation(bool pageOnly)
 		dirty = true;
 	}
 
+	// check for keys a-z
+	if (inputMappings->BrowseLetter())
+	{
+		char temp[8];
+		unsigned found=0;
+		u32 i=0;
+		snprintf (temp, sizeof(temp), "%c", inputMappings->getKeyboardLetter());
+
+		// first look from next to last
+		for (i=1+list->currentIndex; i <= numberOfEntriesMinus1 ; i++)
+		{
+			FileBrowser::BrowsableList::Entry* entry = &list->entries[i];
+			if (strncasecmp(temp, entry->filImage.fname, 1) == 0)
+			{
+				found=i;
+				break;
+			}
+		}
+		if (!found)
+		{
+			// look from first to previous
+			for (i=0; i< 1+list->currentIndex ; i++)
+			{
+				FileBrowser::BrowsableList::Entry* entry = &list->entries[i];
+				if (strncasecmp(temp, entry->filImage.fname, 1) == 0)
+				{
+					found=i;
+					break;
+				}
+			}
+		}
+
+		if (found)
+		{
+			list->currentIndex=found;
+			list->SetCurrent();
+			dirty = true;
+		}
+	}
+
 	return dirty;
 }
 
@@ -360,28 +400,6 @@ FileBrowser::BrowsableList::Entry* FileBrowser::BrowsableList::FindEntry(const c
 		Entry* entry = &entries[index];
 		if (!(entry->filImage.fattrib & AM_DIR) && strcasecmp(name, entry->filImage.fname) == 0)
 			return entry;
-	}
-	return 0;
-}
-
-FileBrowser::BrowsableList::Entry* FileBrowser::BrowsableList::FindNextPartialEntry(const char* name, int match_len)
-{
-	int index;
-	int len = (int)entries.size();
-
-	for (index = 0; index < len; ++index)
-	{
-		Entry* entry = &entries[index];
-		if (match_len) // partial match
-		{
-			if (strncasecmp(name, entry->filImage.fname, match_len) == 0)
-				return entry;
-		}
-		else // full match
-		{
-			if (strcasecmp(name, entry->filImage.fname) == 0)
-				return entry;
-		}
 	}
 	return 0;
 }
@@ -994,15 +1012,6 @@ void FileBrowser::UpdateInputFolders()
 					SelectROMOrDevice(inputMappings->getKeyboardNumber());
 				}
 
-				// check for keys a-z
-				if ( keyboard->KeyAnyHeld() && !keyboard->KeyEitherAlt() )
-				for (unsigned i=KEY_A; i<=KEY_Z; i++)
-				{
-					if (keyboard->KeyPressed( i ))
-					{
-						char ascKey = i-KEY_A+'A';
-					}
-				}
 
 				dirty = folder.CheckBrowseNavigation();
 			}

--- a/src/FileBrowser.h
+++ b/src/FileBrowser.h
@@ -151,7 +151,6 @@ public:
 		};
 
 		Entry* FindEntry(const char* name);
-		Entry* FindNextPartialEntry(const char* name, int match_len);
 		int FindNextAutoName(char* basename);
 
 		void RefreshViews();

--- a/src/FileBrowser.h
+++ b/src/FileBrowser.h
@@ -217,7 +217,7 @@ private:
 	bool CheckForPNG(const char* filename, FILINFO& filIcon);
 	void DisplayPNG();
 
-	bool SelectROM(u32 index);
+	bool SelectROMOrDevice(u32 index);
 
 	enum State
 	{
@@ -232,8 +232,7 @@ private:
 	ROMs* roms;
 	u8* deviceID;
 	bool displayPNGIcons;
-	bool buttonChangedDevice;
-	bool buttonSelectROM;
+	bool buttonChangedROMDevice;
 
 	BrowsableList caddySelections;
 

--- a/src/FileBrowser.h
+++ b/src/FileBrowser.h
@@ -151,6 +151,7 @@ public:
 		};
 
 		Entry* FindEntry(const char* name);
+		Entry* FindNextPartialEntry(const char* name, int match_len);
 		int FindNextAutoName(char* basename);
 
 		void RefreshViews();
@@ -190,8 +191,6 @@ public:
 
 	static const long int LSTBuffer_size = 1024 * 8;
 	static unsigned char LSTBuffer[];
-
-	static const unsigned SwapKeys[];
 
 	static u32 Colour(int index);
 

--- a/src/InputMappings.cpp
+++ b/src/InputMappings.cpp
@@ -191,16 +191,28 @@ bool InputMappings::CheckKeyboardBrowseMode()
 		SetKeyboardFlag(AUTOLOAD_FLAG);
 	else if (keyboard->KeyHeld(KEY_R) && keyboard->KeyEitherAlt() )
 		SetKeyboardFlag(FAKERESET_FLAG);
-	else if (keyboard->KeyHeld(KEY_W) && keyboard->KeyEitherAlt())
+	else if (keyboard->KeyHeld(KEY_W) && keyboard->KeyEitherAlt() )
 		SetKeyboardFlag(WRITEPROTECT_FLAG);
 	else
 	{
 		unsigned index;
-		for (index = 0; index < 11; ++index)
+		for (index = 0; index < sizeof(NumberKeys)/sizeof(NumberKeys[0]); index+=3)
 		{
-			unsigned keySetIndexBase = index * 3;
-			if (keyboard->KeyHeld(FileBrowser::SwapKeys[keySetIndexBase]) || keyboard->KeyHeld(FileBrowser::SwapKeys[keySetIndexBase + 1]) || keyboard->KeyHeld(FileBrowser::SwapKeys[keySetIndexBase + 2]))
-				keyboardFlags |= NUMBER_FLAG;
+			if (keyboard->KeyHeld(NumberKeys[index])
+				|| keyboard->KeyHeld(NumberKeys[index + 1])
+				|| keyboard->KeyHeld(NumberKeys[index + 2]) )
+			{
+				SetKeyboardFlag(NUMBER_FLAG);
+				keyboardNumber = index/3;
+			}
+		}
+		for (index = KEY_A; index <= KEY_Z; ++index)
+		{
+			if (keyboard->KeyHeld(index))
+			{
+				SetKeyboardFlag(AtoZ_FLAG);
+				keyboardNumber = index-KEY_A+1;
+			}
 		}
 	}
 
@@ -227,12 +239,14 @@ void InputMappings::CheckKeyboardEmulationMode(unsigned numberOfImages, unsigned
 		else if (numberOfImages > 1)
 		{
 			unsigned index;
-			for (index = 0; index < numberOfImagesMax; ++index)
+			for (index = 0; index < sizeof(NumberKeys)/sizeof(NumberKeys[0]); index+=3)
 			{
-				unsigned keySetIndexBase = index * 3;
-				if (keyboard->KeyHeld(FileBrowser::SwapKeys[keySetIndexBase]) || keyboard->KeyHeld(FileBrowser::SwapKeys[keySetIndexBase + 1]) || keyboard->KeyHeld(FileBrowser::SwapKeys[keySetIndexBase + 2]))
-					directDiskSwapRequest |= (1 << index);
+				if (keyboard->KeyHeld(NumberKeys[index])
+					|| keyboard->KeyHeld(NumberKeys[index + 1])
+					|| keyboard->KeyHeld(NumberKeys[index + 2]) )
+					directDiskSwapRequest |= (1 << index/3);
 			}
 		}
 	}
 }
+

--- a/src/InputMappings.cpp
+++ b/src/InputMappings.cpp
@@ -195,23 +195,26 @@ bool InputMappings::CheckKeyboardBrowseMode()
 		SetKeyboardFlag(WRITEPROTECT_FLAG);
 	else
 	{
-		unsigned index;
-		for (index = 0; index < sizeof(NumberKeys)/sizeof(NumberKeys[0]); index+=3)
+		if (keyboard->KeyNoModifiers())
 		{
-			if (keyboard->KeyHeld(NumberKeys[index])
-				|| keyboard->KeyHeld(NumberKeys[index + 1])
-				|| keyboard->KeyHeld(NumberKeys[index + 2]) )
+			unsigned index;
+			for (index = 0; index < sizeof(NumberKeys)/sizeof(NumberKeys[0]); index+=3)
 			{
-				SetKeyboardFlag(NUMBER_FLAG);
-				keyboardNumber = index/3;
+				if (keyboard->KeyHeld(NumberKeys[index])
+					|| keyboard->KeyHeld(NumberKeys[index + 1])
+					|| keyboard->KeyHeld(NumberKeys[index + 2]) )
+				{
+					SetKeyboardFlag(NUMBER_FLAG);
+					keyboardNumber = index/3;		// key 1 is 0
+				}
 			}
-		}
-		for (index = KEY_A; index <= KEY_Z; ++index)
-		{
-			if (keyboard->KeyHeld(index))
+			for (index = KEY_A; index <= KEY_Z; ++index)
 			{
-				SetKeyboardFlag(AtoZ_FLAG);
-				keyboardNumber = index-KEY_A+1;
+				if (keyboard->KeyHeld(index))
+				{
+					SetKeyboardFlag(LETTER_FLAG);
+					keyboardLetter = index-KEY_A+'A';	// key A is ascii 'A'
+				}
 			}
 		}
 	}

--- a/src/InputMappings.h
+++ b/src/InputMappings.h
@@ -41,7 +41,23 @@
 #define AUTOLOAD_FLAG		(1 << 15)
 #define FAKERESET_FLAG		(1 << 16)
 #define WRITEPROTECT_FLAG	(1 << 17)
+#define AtoZ_FLAG		(1 << 18)
 // dont exceed 32!!
+
+const unsigned NumberKeys[33] =
+{
+	KEY_F1, KEY_KP1, KEY_1,
+	KEY_F2, KEY_KP2, KEY_2,
+	KEY_F3, KEY_KP3, KEY_3,
+	KEY_F4, KEY_KP4, KEY_4,
+	KEY_F5, KEY_KP5, KEY_5,
+	KEY_F6, KEY_KP6, KEY_6,
+	KEY_F7, KEY_KP7, KEY_7,
+	KEY_F8, KEY_KP8, KEY_8,
+	KEY_F9, KEY_KP9, KEY_9,
+	KEY_F10, KEY_KP0, KEY_0,
+	KEY_F11, KEY_KPMINUS, KEY_MINUS
+};
 
 class InputMappings : public Singleton<InputMappings>
 {
@@ -58,6 +74,9 @@ protected:
 
 	bool enterButtonPressedPrev;
 	bool enterButtonPressed;
+
+	unsigned keyboardNumber;
+	unsigned keyboardLetter;
 
 	//inline void SetUartFlag(unsigned flag) { uartFlags |= flag;	}
 	//inline bool UartFlag(unsigned flag) { return (uartFlags & flag) != 0; }
@@ -179,6 +198,14 @@ public:
 		return KeyboardFlag(WRITEPROTECT_FLAG);
 	}
 
+	inline bool BrowseNumber()
+	{
+		return KeyboardFlag(NUMBER_FLAG);
+	}
+
+	inline unsigned getKeyboardNumber() { return keyboardNumber; }
+	inline unsigned getKeyboardLetter() { return keyboardLetter; }
+
 	// Used by the 2 cores so need to be volatile
 	//volatile static unsigned directDiskSwapRequest;
 	static unsigned directDiskSwapRequest;
@@ -187,3 +214,4 @@ public:
 //	static unsigned escapeSequenceIndex;
 };
 #endif
+

--- a/src/InputMappings.h
+++ b/src/InputMappings.h
@@ -41,7 +41,7 @@
 #define AUTOLOAD_FLAG		(1 << 15)
 #define FAKERESET_FLAG		(1 << 16)
 #define WRITEPROTECT_FLAG	(1 << 17)
-#define AtoZ_FLAG		(1 << 18)
+#define LETTER_FLAG		(1 << 18)
 // dont exceed 32!!
 
 const unsigned NumberKeys[33] =
@@ -203,8 +203,13 @@ public:
 		return KeyboardFlag(NUMBER_FLAG);
 	}
 
+	inline bool BrowseLetter()
+	{
+		return KeyboardFlag(LETTER_FLAG);
+	}
+
 	inline unsigned getKeyboardNumber() { return keyboardNumber; }
-	inline unsigned getKeyboardLetter() { return keyboardLetter; }
+	inline char getKeyboardLetter() { return (char) keyboardLetter; }
 
 	// Used by the 2 cores so need to be volatile
 	//volatile static unsigned directDiskSwapRequest;

--- a/src/Keyboard.h
+++ b/src/Keyboard.h
@@ -348,5 +348,9 @@ public:
 	{
 		return (modifier & (KEY_MOD_LALT | KEY_MOD_RALT) );
 	}
+	inline bool KeyNoModifiers()
+	{
+		return (!modifier );
+	}
 };
 #endif


### PR DESCRIPTION
Why is the existing navigation code in 
browsablelistview::CheckNavigation rather than 
browsablelist::CheckNavigation ?

Historical reasons when there wa only one display ?

Should we move it ?