### PR TITLE
PopDir highlight previous selection, Insert directory, Alt-L to create LST + Code cleanup

### DIFF
--- a/src/FileBrowser.cpp
+++ b/src/FileBrowser.cpp
@@ -375,11 +375,7 @@ bool FileBrowser::BrowsableList::CheckBrowseNavigation()
 	}
 
 	// check for keys a-z and 0-9
-	char searchChar = 0;
-	if (inputMappings->BrowseLetter())
-		searchChar = inputMappings->getKeyboardLetter();
-	if (inputMappings->BrowseNumber())
-		searchChar = inputMappings->getKeyboardNumber();
+	char searchChar = inputMappings->getKeyboardNumLetter();
 	if (searchChar)
 	{
 		char temp[8];
@@ -833,12 +829,7 @@ void FileBrowser::Update()
 		dirty = inputMappings->CheckButtonsBrowseMode();
 
 	if (dirty)
-	{
-		//if (state == State_Folders)
-			UpdateInputFolders();
-		//else
-		//	UpdateInputDiskCaddy();
-	}
+		UpdateInputFolders();
 
 	UpdateCurrentHighlight();
 }
@@ -1049,14 +1040,14 @@ void FileBrowser::UpdateInputFolders()
 			}
 			else
 			{
-				// check for number keys for ROM and Drive Number changes
-				if (inputMappings->BrowseFunction()
-					&& inputMappings->getKeyboardFunction() >= 1
-					&& inputMappings->getKeyboardFunction() <= 11 )
+				// check Fkeys for ROM and Drive Number changes
+				unsigned ROMOrDevice = inputMappings->getROMOrDevice();
+				if ( inputMappings->BrowseFunction()
+					&& ROMOrDevice >= 1
+					&& ROMOrDevice <= 11 )
 				{
-					SelectROMOrDevice(inputMappings->getKeyboardFunction());
+					SelectROMOrDevice(ROMOrDevice);
 				}
-
 
 				dirty = folder.CheckBrowseNavigation();
 			}

--- a/src/FileBrowser.cpp
+++ b/src/FileBrowser.cpp
@@ -756,17 +756,43 @@ void FileBrowser::DisplayPNG()
 
 void FileBrowser::PopFolder()
 {
-	f_chdir("..");
-	//{
-	//	char buffer[1024];
-	//	if (f_getcwd(buffer, 1024) == FR_OK)
-	//	{
-	//		DEBUG_LOG("CWD = %s\r\n", buffer);
-	//	}
-	//}
-	RefreshFolderEntries();
-	caddySelections.Clear();
-	RefeshDisplay();
+	char buffer[1024];
+	if (f_getcwd(buffer, 1024) == FR_OK)
+	{
+		// find the last '/' of the current dir
+		char *last_ptr = 0;
+		char *ptr = strtok(buffer, "/");
+		while (ptr != NULL)
+		{
+			last_ptr = ptr;
+			ptr = strtok(NULL, "/");
+		}
+
+		f_chdir("..");
+		RefreshFolderEntries();
+		caddySelections.Clear();
+
+		unsigned found=0;
+		if (last_ptr)
+		{
+			u32 numberOfEntriesMinus1 = folder.entries.size() - 1;
+			for (unsigned i=0; i <= numberOfEntriesMinus1 ; i++)
+			{
+				FileBrowser::BrowsableList::Entry* entry = &folder.entries[i];
+				if (strcmp(last_ptr, entry->filImage.fname) == 0)
+				{
+					found=i;
+					break;
+				}
+			}
+		}
+		if (found)
+		{
+			folder.currentIndex=found;
+			folder.SetCurrent();
+		}
+		RefeshDisplay();
+	}
 }
 
 void FileBrowser::UpdateCurrentHighlight()

--- a/src/FileBrowser.cpp
+++ b/src/FileBrowser.cpp
@@ -869,6 +869,31 @@ bool FileBrowser::FillCaddyWithSelections()
 
 bool FileBrowser::AddToCaddy(FileBrowser::BrowsableList::Entry* current)
 {
+	if (!current) return false;
+
+	else if (!(current->filImage.fattrib & AM_DIR) && DiskImage::IsDiskImageExtention(current->filImage.fname))
+	{
+		return AddImageToCaddy(current);
+	}
+	else if (current->filImage.fattrib & AM_DIR)
+	{
+		bool ret = false;
+		f_chdir(current->filImage.fname);
+		RefreshFolderEntries();
+		RefeshDisplay();
+
+		for (unsigned i = 0; i < folder.entries.size(); ++i)
+			ret |= AddImageToCaddy(&folder.entries[i]);
+
+		RefeshDisplay();
+		return ret;
+	}
+	return false;
+
+}
+
+bool FileBrowser::AddImageToCaddy(FileBrowser::BrowsableList::Entry* current)
+{
 	bool added = false;
 
 	if (current && !(current->filImage.fattrib & AM_DIR) && DiskImage::IsDiskImageExtention(current->filImage.fname))

--- a/src/FileBrowser.cpp
+++ b/src/FileBrowser.cpp
@@ -875,7 +875,8 @@ bool FileBrowser::AddToCaddy(FileBrowser::BrowsableList::Entry* current)
 	{
 		return AddImageToCaddy(current);
 	}
-	else if (current->filImage.fattrib & AM_DIR)
+
+	else if ( (current->filImage.fattrib & AM_DIR) && ( strcmp(current->filImage.fname, "..") != 0) )
 	{
 		bool ret = false;
 		f_chdir(current->filImage.fname);

--- a/src/FileBrowser.cpp
+++ b/src/FileBrowser.cpp
@@ -886,6 +886,9 @@ bool FileBrowser::AddToCaddy(FileBrowser::BrowsableList::Entry* current)
 		for (unsigned i = 0; i < folder.entries.size(); ++i)
 			ret |= AddImageToCaddy(&folder.entries[i]);
 
+		folder.currentIndex = folder.entries.size() - 1;
+		folder.SetCurrent();
+
 		RefeshDisplay();
 		return ret;
 	}

--- a/src/FileBrowser.h
+++ b/src/FileBrowser.h
@@ -211,6 +211,7 @@ private:
 	bool FillCaddyWithSelections();
 
 	bool AddToCaddy(FileBrowser::BrowsableList::Entry* current);
+	bool AddImageToCaddy(FileBrowser::BrowsableList::Entry* current);
 
 	bool CheckForPNG(const char* filename, FILINFO& filIcon);
 	void DisplayPNG();

--- a/src/FileBrowser.h
+++ b/src/FileBrowser.h
@@ -193,6 +193,7 @@ public:
 
 	static u32 Colour(int index);
 
+	bool MakeLST(const char* filenameLST);
 	bool SelectLST(const char* filenameLST);
 
 	void SetScrollHighlightRate(float value) { scrollHighlightRate = value; }

--- a/src/InputMappings.cpp
+++ b/src/InputMappings.cpp
@@ -198,6 +198,10 @@ bool InputMappings::CheckKeyboardBrowseMode()
 
 	keyboardFlags = 0;
 	keyboardNumLetter = 0;
+	if (!keyboard->CheckChanged())
+	{
+		return false;
+	}
 
 	if (keyboard->KeyHeld(KEY_DELETE) && keyboard->KeyLCtrlAlt() )
 		reboot_now();
@@ -293,32 +297,31 @@ void InputMappings::CheckKeyboardEmulationMode(unsigned numberOfImages, unsigned
 	Keyboard* keyboard = Keyboard::Instance();
 
 	keyboardFlags = 0;
-	if (keyboard->CheckChanged())
+	if (!keyboard->CheckChanged())
+		return;
+
+	if (keyboard->KeyHeld(KEY_DELETE) && keyboard->KeyLCtrlAlt() )
+		reboot_now();
+
+	if (keyboard->KeyHeld(KEY_ESC))
+		SetKeyboardFlag(ESC_FLAG);
+	else if (keyboard->KeyHeld(KEY_PAGEUP))
+		SetKeyboardFlag(PREV_FLAG);
+	else if (keyboard->KeyHeld(KEY_PAGEDOWN))
+		SetKeyboardFlag(NEXT_FLAG);
+	else if (keyboard->KeyHeld(KEY_A) && keyboard->KeyEitherAlt() )
+		SetKeyboardFlag(AUTOLOAD_FLAG);
+	else if (keyboard->KeyHeld(KEY_R) && keyboard->KeyEitherAlt() )
+		SetKeyboardFlag(FAKERESET_FLAG);
+	else if (numberOfImages > 1)
 	{
-
-		if (keyboard->KeyHeld(KEY_DELETE) && keyboard->KeyLCtrlAlt() )
-			reboot_now();
-
-		if (keyboard->KeyHeld(KEY_ESC))
-			SetKeyboardFlag(ESC_FLAG);
-		else if (keyboard->KeyHeld(KEY_PAGEUP))
-			SetKeyboardFlag(PREV_FLAG);
-		else if (keyboard->KeyHeld(KEY_PAGEDOWN))
-			SetKeyboardFlag(NEXT_FLAG);
-		else if (keyboard->KeyHeld(KEY_A) && keyboard->KeyEitherAlt() )
-			SetKeyboardFlag(AUTOLOAD_FLAG);
-		else if (keyboard->KeyHeld(KEY_R) && keyboard->KeyEitherAlt() )
-			SetKeyboardFlag(FAKERESET_FLAG);
-		else if (numberOfImages > 1)
+		unsigned index;
+		for (index = 0; index < 10; index++)
 		{
-			unsigned index;
-			for (index = 0; index < sizeof(NumberKeys)/sizeof(NumberKeys[0]); index+=3)
-			{
-				if (keyboard->KeyHeld(NumberKeys[index])
-					|| keyboard->KeyHeld(NumberKeys[index + 1])
-					|| keyboard->KeyHeld(NumberKeys[index + 2]) )
-					directDiskSwapRequest |= (1 << index/3);
-			}
+			if ( keyboard->KeyHeld(KEY_F1+index)
+				|| keyboard->KeyHeld(KEY_1+index)
+				|| keyboard->KeyHeld(KEY_KP1+index) )
+				directDiskSwapRequest |= (1 << index);
 		}
 	}
 }

--- a/src/InputMappings.cpp
+++ b/src/InputMappings.cpp
@@ -246,30 +246,24 @@ bool InputMappings::CheckKeyboardBrowseMode()
 		SetKeyboardFlag(FAKERESET_FLAG);
 	else if (keyboard->KeyHeld(KEY_W) && keyboard->KeyEitherAlt() )
 		SetKeyboardFlag(WRITEPROTECT_FLAG);
+	else if (keyboard->KeyHeld(KEY_L) && keyboard->KeyEitherAlt() )
+		SetKeyboardFlag(MAKELST_FLAG);
 	else
 	{
 		if (keyboard->KeyNoModifiers())
 		{
 			unsigned index;
 
-			for (index = KEY_1; index <= KEY_0; ++index)
+			for (index = 0; index <= 9; ++index)
 			{
-				if (keyboard->KeyHeld(index))
+				if (keyboard->KeyHeld(KEY_1+index) || keyboard->KeyHeld(KEY_KP1+index))
 				{
 					SetKeyboardFlag(NUMLET_FLAG);
-					keyboardNumLetter = index-KEY_1+'1';	// key 1 is ascii '1'
+					keyboardNumLetter = index+'1';	// key 1 is ascii '1'
 					if (keyboardNumLetter > '9') keyboardNumLetter = '0';
 				}
 			}
-			for (index = KEY_KP1; index <= KEY_KP0; ++index)
-			{
-				if (keyboard->KeyHeld(index))
-				{
-					SetKeyboardFlag(NUMLET_FLAG);
-					keyboardNumLetter = index-KEY_KP1+'1';	// key 1 is ascii '1'
-					if (keyboardNumLetter > '9') keyboardNumLetter = '0';
-				}
-			}
+
 			for (index = KEY_A; index <= KEY_Z; ++index)
 			{
 				if (keyboard->KeyHeld(index))

--- a/src/InputMappings.cpp
+++ b/src/InputMappings.cpp
@@ -44,11 +44,58 @@ InputMappings::InputMappings()
 bool InputMappings::CheckButtonsBrowseMode()
 {
 	buttonFlags = 0;
-	if (IEC_Bus::GetInputButtonRepeating(1))
+
+	if (IEC_Bus::GetInputButtonHeld(INPUT_BUTTON_INSERT))	// Change DeviceID
+	{
+		if (IEC_Bus::GetInputButtonRepeating(INPUT_BUTTON_ENTER))
+		{
+			SetButtonFlag(FUNCTION_FLAG);
+			inputROMOrDevice = 8;
+		}
+		else if (IEC_Bus::GetInputButtonRepeating(INPUT_BUTTON_UP))
+		{
+			SetButtonFlag(FUNCTION_FLAG);
+			inputROMOrDevice = 9;
+		}
+		else if (IEC_Bus::GetInputButtonRepeating(INPUT_BUTTON_DOWN))
+		{
+			SetButtonFlag(FUNCTION_FLAG);
+			inputROMOrDevice = 10;
+		}
+		else if (IEC_Bus::GetInputButtonRepeating(INPUT_BUTTON_BACK))
+		{
+			SetButtonFlag(FUNCTION_FLAG);
+			inputROMOrDevice = 11;
+		}
+	}
+	else if (IEC_Bus::GetInputButtonHeld(INPUT_BUTTON_ENTER))	// Change ROMs
+	{
+		if (IEC_Bus::GetInputButtonRepeating(INPUT_BUTTON_UP))
+		{
+			SetButtonFlag(FUNCTION_FLAG);
+			inputROMOrDevice = 1;
+		}
+		else if (IEC_Bus::GetInputButtonRepeating(INPUT_BUTTON_DOWN))
+		{
+			SetButtonFlag(FUNCTION_FLAG);
+			inputROMOrDevice = 2;
+		}
+		else if (IEC_Bus::GetInputButtonRepeating(INPUT_BUTTON_BACK))
+		{
+			SetButtonFlag(FUNCTION_FLAG);
+			inputROMOrDevice = 3;
+		}
+		else if (IEC_Bus::GetInputButtonRepeating(INPUT_BUTTON_INSERT))
+		{
+			SetButtonFlag(FUNCTION_FLAG);
+			inputROMOrDevice = 4;
+		}
+	}
+	else if (IEC_Bus::GetInputButtonRepeating(INPUT_BUTTON_UP))
 		SetButtonFlag(UP_FLAG);
-	else if (IEC_Bus::GetInputButtonRepeating(2))
+	else if (IEC_Bus::GetInputButtonRepeating(INPUT_BUTTON_DOWN))
 		SetButtonFlag(DOWN_FLAG);
-	else if (IEC_Bus::GetInputButtonPressed(3))
+	else if (IEC_Bus::GetInputButtonPressed(INPUT_BUTTON_BACK))
 		SetButtonFlag(BACK_FLAG);
 
 // edge detection
@@ -69,14 +116,16 @@ void InputMappings::CheckButtonsEmulationMode()
 {
 	buttonFlags = 0;
 
-	if (IEC_Bus::GetInputButtonPressed(0))
+	if (IEC_Bus::GetInputButtonPressed(INPUT_BUTTON_ENTER))
 		SetButtonFlag(ESC_FLAG);
-	else if (IEC_Bus::GetInputButtonPressed(1))
+	else if (IEC_Bus::GetInputButtonPressed(INPUT_BUTTON_UP))
 		SetButtonFlag(NEXT_FLAG);
-	else if (IEC_Bus::GetInputButtonPressed(2))
+	else if (IEC_Bus::GetInputButtonPressed(INPUT_BUTTON_DOWN))
 		SetButtonFlag(PREV_FLAG);
-	//else if (IEC_Bus::GetInputButtonPressed(3))
+	//else if (IEC_Bus::GetInputButtonPressed(INPUT_BUTTON_BACK))
 	//	SetButtonFlag(BACK_FLAG);
+	//else if (IEC_Bus::GetInputButtonPressed(INPUT_BUTTON_INSERT))
+	//	SetButtonFlag(INSERT_FLAG);
 }
 
 
@@ -148,7 +197,6 @@ bool InputMappings::CheckKeyboardBrowseMode()
 	Keyboard* keyboard = Keyboard::Instance();
 
 	keyboardFlags = 0;
-	inputROMOrDevice = 0;
 	keyboardNumLetter = 0;
 
 	if (keyboard->KeyHeld(KEY_DELETE) && keyboard->KeyLCtrlAlt() )

--- a/src/InputMappings.cpp
+++ b/src/InputMappings.cpp
@@ -44,18 +44,14 @@ InputMappings::InputMappings()
 bool InputMappings::CheckButtonsBrowseMode()
 {
 	buttonFlags = 0;
-	//if (IEC_Bus::GetInputButtonPressed(0))
-	//	SetButtonFlag(ENTER_FLAG);
-	//else
-		if (IEC_Bus::GetInputButtonRepeating(1))
+	if (IEC_Bus::GetInputButtonRepeating(1))
 		SetButtonFlag(UP_FLAG);
 	else if (IEC_Bus::GetInputButtonRepeating(2))
 		SetButtonFlag(DOWN_FLAG);
 	else if (IEC_Bus::GetInputButtonPressed(3))
 		SetButtonFlag(BACK_FLAG);
-	//else if (IEC_Bus::GetInputButtonPressed(4))
-	//	SetButtonFlag(INSERT_FLAG);
 
+// edge detection
 	insertButtonPressed = !IEC_Bus::GetInputButtonReleased(4);
 	if (insertButtonPressedPrev && !insertButtonPressed)
 		SetButtonFlag(INSERT_FLAG);
@@ -152,6 +148,8 @@ bool InputMappings::CheckKeyboardBrowseMode()
 	Keyboard* keyboard = Keyboard::Instance();
 
 	keyboardFlags = 0;
+	inputROMOrDevice = 0;
+	keyboardNumLetter = 0;
 
 	if (keyboard->KeyHeld(KEY_DELETE) && keyboard->KeyLCtrlAlt() )
 		reboot_now();
@@ -206,26 +204,26 @@ bool InputMappings::CheckKeyboardBrowseMode()
 			{
 				if (keyboard->KeyHeld(index))
 				{
-					SetKeyboardFlag(NUMBER_FLAG);
-					keyboardNumber = index-KEY_1+'1';	// key 1 is ascii '1'
-					if (keyboardNumber > '9') keyboardNumber = '0';
+					SetKeyboardFlag(NUMLET_FLAG);
+					keyboardNumLetter = index-KEY_1+'1';	// key 1 is ascii '1'
+					if (keyboardNumLetter > '9') keyboardNumLetter = '0';
 				}
 			}
 			for (index = KEY_KP1; index <= KEY_KP0; ++index)
 			{
 				if (keyboard->KeyHeld(index))
 				{
-					SetKeyboardFlag(NUMBER_FLAG);
-					keyboardNumber = index-KEY_KP1+'1';	// key 1 is ascii '1'
-					if (keyboardNumber > '9') keyboardNumber = '0';
+					SetKeyboardFlag(NUMLET_FLAG);
+					keyboardNumLetter = index-KEY_KP1+'1';	// key 1 is ascii '1'
+					if (keyboardNumLetter > '9') keyboardNumLetter = '0';
 				}
 			}
 			for (index = KEY_A; index <= KEY_Z; ++index)
 			{
 				if (keyboard->KeyHeld(index))
 				{
-					SetKeyboardFlag(LETTER_FLAG);
-					keyboardLetter = index-KEY_A+'A';	// key A is ascii 'A'
+					SetKeyboardFlag(NUMLET_FLAG);
+					keyboardNumLetter = index-KEY_A+'A';	// key A is ascii 'A'
 				}
 			}
 			for (index = KEY_F1; index <= KEY_F12; ++index)	// F13 isnt contiguous
@@ -233,7 +231,7 @@ bool InputMappings::CheckKeyboardBrowseMode()
 				if (keyboard->KeyHeld(index))
 				{
 					SetKeyboardFlag(FUNCTION_FLAG);
-					keyboardFunction = index-KEY_F1+1;	// key F1 is 1
+					inputROMOrDevice = index-KEY_F1+1;	// key F1 is 1
 				}
 			}
 		}

--- a/src/InputMappings.h
+++ b/src/InputMappings.h
@@ -49,20 +49,6 @@
 #define FUNCTION_FLAG		(1 << 21)
 // dont exceed 32!!
 
-const unsigned NumberKeys[33] =
-{
-	KEY_F1, KEY_KP1, KEY_1,
-	KEY_F2, KEY_KP2, KEY_2,
-	KEY_F3, KEY_KP3, KEY_3,
-	KEY_F4, KEY_KP4, KEY_4,
-	KEY_F5, KEY_KP5, KEY_5,
-	KEY_F6, KEY_KP6, KEY_6,
-	KEY_F7, KEY_KP7, KEY_7,
-	KEY_F8, KEY_KP8, KEY_8,
-	KEY_F9, KEY_KP9, KEY_9,
-	KEY_F10, KEY_KP0, KEY_0,
-	KEY_F11, KEY_KPMINUS, KEY_MINUS
-};
 
 class InputMappings : public Singleton<InputMappings>
 {

--- a/src/InputMappings.h
+++ b/src/InputMappings.h
@@ -32,7 +32,8 @@
 #define SPACE_FLAG		(1 << 8)
 #define BACK_FLAG		(1 << 9)
 #define INSERT_FLAG		(1 << 10)
-#define NUMBER_FLAG		(1 << 11)
+
+#define NUMLET_FLAG		(1 << 11)
 
 #define PAGEDOWN_LCD_FLAG	(1 << 12)
 #define PAGEUP_LCD_FLAG		(1 << 13)
@@ -41,9 +42,10 @@
 #define AUTOLOAD_FLAG		(1 << 15)
 #define FAKERESET_FLAG		(1 << 16)
 #define WRITEPROTECT_FLAG	(1 << 17)
-#define LETTER_FLAG		(1 << 18)
+//#define SPARE_FLAG		(1 << 18)
 #define HOME_FLAG		(1 << 19)
 #define END_FLAG		(1 << 20)
+
 #define FUNCTION_FLAG		(1 << 21)
 // dont exceed 32!!
 
@@ -78,9 +80,8 @@ protected:
 	bool enterButtonPressedPrev;
 	bool enterButtonPressed;
 
-	unsigned keyboardNumber;
-	unsigned keyboardLetter;
-	unsigned keyboardFunction;
+	unsigned keyboardNumLetter;
+	unsigned inputROMOrDevice;
 
 	//inline void SetUartFlag(unsigned flag) { uartFlags |= flag;	}
 	//inline bool UartFlag(unsigned flag) { return (uartFlags & flag) != 0; }
@@ -178,17 +179,14 @@ public:
 
 	inline bool BrowseWriteProtect() { return KeyboardFlag(WRITEPROTECT_FLAG); }
 
-	inline bool BrowseNumber() { return KeyboardFlag(NUMBER_FLAG); }
-	inline bool BrowseLetter() { return KeyboardFlag(LETTER_FLAG); }
 	inline bool BrowseFunction() { return KeyboardFlag(FUNCTION_FLAG); }
 
 	inline bool BrowseHome() { return KeyboardFlag(HOME_FLAG); }
 
 	inline bool BrowseEnd() { return KeyboardFlag(END_FLAG); }
 
-	inline char getKeyboardNumber() { return keyboardNumber; }
-	inline char getKeyboardLetter() { return (char) keyboardLetter; }
-	inline unsigned getKeyboardFunction() { return (char) keyboardFunction; }
+	inline char getKeyboardNumLetter() { return keyboardNumLetter; }
+	inline unsigned getROMOrDevice() { return inputROMOrDevice; }
 
 	// Used by the 2 cores so need to be volatile
 	//volatile static unsigned directDiskSwapRequest;

--- a/src/InputMappings.h
+++ b/src/InputMappings.h
@@ -42,7 +42,7 @@
 #define AUTOLOAD_FLAG		(1 << 15)
 #define FAKERESET_FLAG		(1 << 16)
 #define WRITEPROTECT_FLAG	(1 << 17)
-//#define SPARE_FLAG		(1 << 18)
+#define MAKELST_FLAG		(1 << 18)
 #define HOME_FLAG		(1 << 19)
 #define END_FLAG		(1 << 20)
 
@@ -169,6 +169,8 @@ public:
 	inline bool BrowseFakeReset() { return KeyboardFlag(FAKERESET_FLAG); }
 
 	inline bool BrowseWriteProtect() { return KeyboardFlag(WRITEPROTECT_FLAG); }
+
+	inline bool MakeLSTFile() { return KeyboardFlag(MAKELST_FLAG); }
 
 	inline bool BrowseHome() { return KeyboardFlag(HOME_FLAG); }
 

--- a/src/InputMappings.h
+++ b/src/InputMappings.h
@@ -171,6 +171,11 @@ public:
 		return KeyboardFlag(INSERT_FLAG)/* | UartFlag(INSERT_FLAG)*/ | ButtonFlag(INSERT_FLAG);
 	}
 
+	inline bool BrowseFunction()
+	{
+		return KeyboardFlag(FUNCTION_FLAG) | ButtonFlag(FUNCTION_FLAG);
+	}
+
 	inline bool BrowseNewD64() { return KeyboardFlag(NEWD64_FLAG); }
 
 	inline bool BrowseAutoLoad() { return KeyboardFlag(AUTOLOAD_FLAG); }
@@ -178,8 +183,6 @@ public:
 	inline bool BrowseFakeReset() { return KeyboardFlag(FAKERESET_FLAG); }
 
 	inline bool BrowseWriteProtect() { return KeyboardFlag(WRITEPROTECT_FLAG); }
-
-	inline bool BrowseFunction() { return KeyboardFlag(FUNCTION_FLAG); }
 
 	inline bool BrowseHome() { return KeyboardFlag(HOME_FLAG); }
 

--- a/src/iec_bus.h
+++ b/src/iec_bus.h
@@ -28,6 +28,12 @@
 #define INPUT_BUTTON_DEBOUNCE_THRESHOLD 20000
 #define INPUT_BUTTON_REPEAT_THRESHOLD 460000
 
+#define INPUT_BUTTON_ENTER 0
+#define INPUT_BUTTON_UP 1
+#define INPUT_BUTTON_DOWN 2
+#define INPUT_BUTTON_BACK 3
+#define INPUT_BUTTON_INSERT 4
+
 // DIN ATN is inverted and then connected to pb7 and ca1
 //	- also input to xor with ATNAout pb4
 //		- output of xor is inverted and connected to DIN pin 5 DATAout (OC so can only pull low)


### PR DESCRIPTION
In Browser mode:
1) when you go to parent directory, it now highlights to directory you were in rather than placing the highlight at the 1st entry (..)
2) Alt-L to create autoswap.lst in the current directory with all disk images included. any existing autoswap.lst file is overwritten
3) You can now "Insert" a directory. it will change into that dir, then add all the images to the caddy

Can you please review the  “remove len>0 check from FileBrowser::UpdateInputFolders()“
The diff is a bit wild, but in reality it’s remove that check and lots of out denting