### PR TITLE
use bitmap view of the BAM (rather than characters)

### DIFF
--- a/src/Screen.cpp
+++ b/src/Screen.cpp
@@ -146,7 +146,7 @@ void Screen::PlotPixel8(u32 pixel_offset, RGBA Colour)
 	framebuffer[pixel_offset++] = RED(Colour);
 }
 
-void Screen::ClearArea(u32 x1, u32 y1, u32 x2, u32 y2, RGBA colour)
+void Screen::DrawRectangle(u32 x1, u32 y1, u32 x2, u32 y2, RGBA colour)
 {
 	ClipRect(x1, y1, x2, y2);
 
@@ -182,7 +182,7 @@ void Screen::ScrollArea(u32 x1, u32 y1, u32 x2, u32 y2)
 
 void Screen::Clear(RGBA colour)
 {
-	ClearArea(0, 0, width, height, colour);
+	DrawRectangle(0, 0, width, height, colour);
 }
 
 u32 Screen::GetFontHeight()
@@ -299,7 +299,7 @@ u32 Screen::PrintText(bool petscii, u32 x, u32 y, char *ptr, RGBA TxtColour, RGB
 		{
 			if (!measureOnly)
 			{
-				ClearArea(xCursor, yCursor, xCursor + BitFontWth, yCursor + fontHeight, BkColour);
+				DrawRectangle(xCursor, yCursor, xCursor + BitFontWth, yCursor + fontHeight, BkColour);
 				WriteChar(petscii, xCursor, yCursor, c, TxtColour);
 			}
 			xCursor += BitFontWth;

--- a/src/Screen.h
+++ b/src/Screen.h
@@ -32,7 +32,7 @@ public:
 
 	void Open(u32 width, u32 height, u32 colourDepth);
 
-	void ClearArea(u32 x1, u32 y1, u32 x2, u32 y2, RGBA colour);
+	void DrawRectangle(u32 x1, u32 y1, u32 x2, u32 y2, RGBA colour);
 	void Clear(RGBA colour);
 
 	void ScrollArea(u32 x1, u32 y1, u32 x2, u32 y2);

--- a/src/ScreenBase.h
+++ b/src/ScreenBase.h
@@ -46,7 +46,7 @@ public:
 	{
 	}
 
-	virtual void ClearArea(u32 x1, u32 y1, u32 x2, u32 y2, RGBA colour) = 0;
+	virtual void DrawRectangle(u32 x1, u32 y1, u32 x2, u32 y2, RGBA colour) = 0;
 	virtual void Clear(RGBA colour) = 0;
 
 	virtual void ScrollArea(u32 x1, u32 y1, u32 x2, u32 y2) = 0;

--- a/src/ScreenLCD.cpp
+++ b/src/ScreenLCD.cpp
@@ -47,7 +47,7 @@ void ScreenLCD::Open(u32 widthDesired, u32 heightDesired, u32 colourDepth, int B
 	opened = true;
 }
 
-void ScreenLCD::ClearArea(u32 x1, u32 y1, u32 x2, u32 y2, RGBA colour)
+void ScreenLCD::DrawRectangle(u32 x1, u32 y1, u32 x2, u32 y2, RGBA colour)
 {
 	ClipRect(x1, y1, x2, y2);
 }

--- a/src/ScreenLCD.h
+++ b/src/ScreenLCD.h
@@ -35,7 +35,7 @@ public:
 
 	void Open(u32 width, u32 height, u32 colourDepth, int BSCMaster, int LCDAddress, int LCDFlip, LCD_MODEL LCDType);
 
-	void ClearArea(u32 x1, u32 y1, u32 x2, u32 y2, RGBA colour);
+	void DrawRectangle(u32 x1, u32 y1, u32 x2, u32 y2, RGBA colour);
 	void Clear(RGBA colour);
 	void ClearInit(RGBA colour);
 


### PR DESCRIPTION
It is scaled to PNG  bitmap size and rotated 90degrees to fit the aspect ratio.
Tracks from left to right, sectors from top to bottom.

It guesses 40 track format for BAM display and marks them black if it cant decide

rename ClearArea() to DrawRectangle()