### PR TITLE
Configurable PCB button mapping

### DIFF
--- a/options.txt
+++ b/options.txt
@@ -91,8 +91,9 @@ GraphIEC = 1
 //IgnoreReset = 0
 
 // You can remap the physical button functions
-//buttonEnter = 0
-//buttonUp = 1
-//buttonDown = 2
-//buttonBack = 3
-//buttonInsert = 4
+// numbers correspond to the standard board layout
+//buttonEnter = 1
+//buttonUp = 2
+//buttonDown = 3
+//buttonBack = 4
+//buttonInsert = 5

--- a/options.txt
+++ b/options.txt
@@ -90,3 +90,9 @@ GraphIEC = 1
 //ShowOptions = 0	// display some options on startup screen 
 //IgnoreReset = 0
 
+// You can remap the physical button functions
+//buttonEnter = 0
+//buttonUp = 1
+//buttonDown = 2
+//buttonBack = 3
+//buttonInsert = 4

--- a/src/InputMappings.cpp
+++ b/src/InputMappings.cpp
@@ -99,12 +99,12 @@ bool InputMappings::CheckButtonsBrowseMode()
 		SetButtonFlag(BACK_FLAG);
 
 // edge detection
-	insertButtonPressed = !IEC_Bus::GetInputButtonReleased(4);
+	insertButtonPressed = !IEC_Bus::GetInputButtonReleased(INPUT_BUTTON_INSERT);
 	if (insertButtonPressedPrev && !insertButtonPressed)
 		SetButtonFlag(INSERT_FLAG);
 	insertButtonPressedPrev = insertButtonPressed;
 
-	enterButtonPressed = !IEC_Bus::GetInputButtonReleased(0);
+	enterButtonPressed = !IEC_Bus::GetInputButtonReleased(INPUT_BUTTON_ENTER);
 	if (enterButtonPressedPrev && !enterButtonPressed)
 		SetButtonFlag(ENTER_FLAG);
 	enterButtonPressedPrev = enterButtonPressed;

--- a/src/InputMappings.h
+++ b/src/InputMappings.h
@@ -85,6 +85,12 @@ public:
 	bool CheckButtonsBrowseMode();
 	void CheckButtonsEmulationMode();
 
+	u8 INPUT_BUTTON_ENTER = 0;
+	u8 INPUT_BUTTON_UP = 1;
+	u8 INPUT_BUTTON_DOWN = 2;
+	u8 INPUT_BUTTON_BACK = 3;
+	u8 INPUT_BUTTON_INSERT = 4;
+
 	void Reset()
 	{
 		keyboardFlags = 0;

--- a/src/iec_bus.h
+++ b/src/iec_bus.h
@@ -28,11 +28,13 @@
 #define INPUT_BUTTON_DEBOUNCE_THRESHOLD 20000
 #define INPUT_BUTTON_REPEAT_THRESHOLD 460000
 
+/* moved to variables in InputMapping
 #define INPUT_BUTTON_ENTER 0
 #define INPUT_BUTTON_UP 1
 #define INPUT_BUTTON_DOWN 2
 #define INPUT_BUTTON_BACK 3
 #define INPUT_BUTTON_INSERT 4
+*/
 
 // DIN ATN is inverted and then connected to pb7 and ca1
 //	- also input to xor with ATNAout pb4

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1348,9 +1348,15 @@ extern "C"
 		//	DEBUG_LOG("Mouse found\r\n");
 
 		Keyboard::Instance();
-		InputMappings::Instance();
+//		InputMappings::Instance();
+		InputMappings* inputMappings = InputMappings::Instance();
 		//USPiMouseRegisterStatusHandler(MouseHandler);
 
+		inputMappings->INPUT_BUTTON_ENTER = options.GetButtonEnter();
+		inputMappings->INPUT_BUTTON_UP = options.GetButtonUp();
+		inputMappings->INPUT_BUTTON_DOWN = options.GetButtonDown();
+		inputMappings->INPUT_BUTTON_BACK = options.GetButtonBack();
+		inputMappings->INPUT_BUTTON_INSERT = options.GetButtonInsert();
 
 		CheckOptions();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1289,6 +1289,20 @@ static void CheckOptions()
 		}
 		while (1);
 	}
+
+
+	InputMappings* inputMappings = InputMappings::Instance();
+	if (options.GetButtonEnter() )
+		inputMappings->INPUT_BUTTON_ENTER = options.GetButtonEnter()-1;
+	if (options.GetButtonUp() )
+		inputMappings->INPUT_BUTTON_UP = options.GetButtonUp()-1;
+	if (options.GetButtonDown() )
+		inputMappings->INPUT_BUTTON_DOWN = options.GetButtonDown()-1;
+	if (options.GetButtonBack() )
+		inputMappings->INPUT_BUTTON_BACK = options.GetButtonBack()-1;
+	if (options.GetButtonInsert() )
+		inputMappings->INPUT_BUTTON_INSERT = options.GetButtonInsert()-1;
+
 }
 
 extern "C"
@@ -1348,15 +1362,8 @@ extern "C"
 		//	DEBUG_LOG("Mouse found\r\n");
 
 		Keyboard::Instance();
-//		InputMappings::Instance();
-		InputMappings* inputMappings = InputMappings::Instance();
+		InputMappings::Instance();
 		//USPiMouseRegisterStatusHandler(MouseHandler);
-
-		inputMappings->INPUT_BUTTON_ENTER = options.GetButtonEnter();
-		inputMappings->INPUT_BUTTON_UP = options.GetButtonUp();
-		inputMappings->INPUT_BUTTON_DOWN = options.GetButtonDown();
-		inputMappings->INPUT_BUTTON_BACK = options.GetButtonBack();
-		inputMappings->INPUT_BUTTON_INSERT = options.GetButtonInsert();
 
 		CheckOptions();
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -149,6 +149,12 @@ Options::Options(void)
 	, i2cLcdModel(LCD_UNKNOWN)
 	, scrollHighlightRate(0.125f)
 	, keyboardBrowseLCDScreen(0)
+        , buttonEnter(0)
+        , buttonUp(1)
+        , buttonDown(2)
+        , buttonBack(3)
+        , buttonInsert(4)
+
 {
 	autoMountImageName[0] = 0;
 	strcpy(ROMFontName, "chargen");
@@ -228,6 +234,11 @@ void Options::Process(char* buffer)
 		ELSE_CHECK_DECIMAL_OPTION(i2cLcdDimTime)
 		ELSE_CHECK_FLOAT_OPTION(scrollHighlightRate)
 		ELSE_CHECK_DECIMAL_OPTION(keyboardBrowseLCDScreen)
+		ELSE_CHECK_DECIMAL_OPTION(buttonEnter)
+		ELSE_CHECK_DECIMAL_OPTION(buttonUp)
+		ELSE_CHECK_DECIMAL_OPTION(buttonDown)
+		ELSE_CHECK_DECIMAL_OPTION(buttonBack)
+		ELSE_CHECK_DECIMAL_OPTION(buttonInsert)
 		else if ((strcasecmp(pOption, "AutoBaseName") == 0))
 		{
 			strncpy(autoBaseName, pValue, 255);

--- a/src/options.h
+++ b/src/options.h
@@ -88,6 +88,12 @@ public:
 
 	inline float ScrollHighlightRate() const { return scrollHighlightRate; }
 
+	inline unsigned int GetButtonEnter() const { return buttonEnter; }
+	inline unsigned int GetButtonUp() const { return buttonUp; }
+	inline unsigned int GetButtonDown() const { return buttonDown; }
+	inline unsigned int GetButtonBack() const { return buttonBack; }
+	inline unsigned int GetButtonInsert() const { return buttonInsert; }
+
 	// Page up and down will jump a different amount based on the maximum number rows displayed.
 	// Perhaps we should use some keyboard modifier to the the other screen?
 	inline unsigned int KeyboardBrowseLCDScreen() const { return keyboardBrowseLCDScreen; }
@@ -134,6 +140,12 @@ private:
 	float scrollHighlightRate;
 
 	unsigned int keyboardBrowseLCDScreen;
+
+        u8 buttonEnter;
+        u8 buttonUp;
+        u8 buttonDown;
+        u8 buttonBack;
+        u8 buttonInsert;
 
 	char starFileName[256];
 	char C128BootSectorName[256];


### PR DESCRIPTION
// You can remap the physical button functions
// numbers correspond to the standard board layout (1 is sw1)
//buttonEnter = 1
//buttonUp = 2
//buttonDown = 3
//buttonBack = 4
//buttonInsert = 5