### PR TITLE
Correct a bug on displaying caddy content when using 8bit height font

### DIFF
--- a/src/DiskCaddy.cpp
+++ b/src/DiskCaddy.cpp
@@ -298,7 +298,7 @@ void DiskCaddy::ShowSelectedImage(u32 index)
 	if (screenLCD)
 	{
 		unsigned numberOfImages = GetNumberOfImages();
-		unsigned numberOfDisplayedImages = screenLCD->Height()/screenLCD->GetFontHeight()-1;
+		unsigned numberOfDisplayedImages = (screenLCD->Height()/screenLCD->GetFontHeight())-1;
 		unsigned caddyIndex;
 
 		RGBA BkColour = RGBA(0, 0, 0, 0xFF);

--- a/src/DiskCaddy.h
+++ b/src/DiskCaddy.h
@@ -100,7 +100,7 @@ private:
 	u32 selectedIndex;
 	u32 oldCaddyIndex;
 
-	Screen* screen;
+	ScreenBase* screen;
 	ScreenBase* screenLCD;
 };
 

--- a/src/FileBrowser.cpp
+++ b/src/FileBrowser.cpp
@@ -181,7 +181,7 @@ void FileBrowser::BrowsableListView::Refresh()
 		entryIndex = offset + index;
 
 		RefreshLine(entryIndex, x, y, /*showSelected && */list->currentIndex == entryIndex);
-		y += 16;
+		y += screen->GetFontHeight ();
 	}
 
 	screen->SwapBuffers();
@@ -248,7 +248,7 @@ void FileBrowser::BrowsableListView::RefreshHighlightScroll()
 		int rowIndex = list->currentIndex - offset;
 		
 		u32 y = positionY;
-		y += rowIndex * 16;
+		y += rowIndex * screen->GetFontHeight ();
 
 		RefreshLine(list->currentIndex, 0, y, true);
 

--- a/src/ScreenLCD.cpp
+++ b/src/ScreenLCD.cpp
@@ -103,7 +103,7 @@ void ScreenLCD::PlotRawImage(const u8* image, int x, int y, int w, int h)
 u32 ScreenLCD::PrintText(bool petscii, u32 x, u32 y, char *ptr, RGBA TxtColour, RGBA BkColour, bool measureOnly, u32* width, u32* height)
 {
 	int len = 0;
-	ssd1306->PlotText(UseCBMFont(), petscii, x >> 3, y >> 4, ptr, (BkColour & 0xffffff) != 0);
+	ssd1306->PlotText(UseCBMFont(), petscii, x >> 3, y / GetFontHeight (), ptr, (BkColour & 0xffffff) != 0);
 	return len;
 }
 


### PR DESCRIPTION
The previous patch didn't work as expected. There was a bug on the use of y coordinate in the PrintText method where it assume to always have a 16 pixel height character.
This time, with the correct y coordinate usage.