### PR TITLE
A little improvment on SSD refresh

### DIFF
--- a/src/SSD1306.h
+++ b/src/SSD1306.h
@@ -98,6 +98,7 @@ public:
 protected:
 	void SendCommand(u8 command);
 	void SendData(u8 data);
+	void SendDataLong(void* data, u8 length);
 
 	void Home();
 	void SetDataPointer(u8 row, u8 col);


### PR DESCRIPTION
By using the ability to send up to 15 bytes in one single data command.
Should increase the speed to refresh the screen.
Again, I Don't know why GitHub show the whole files as a diff.
In reality the changes are :
- new private method 
  void SendDataLong(void* data, u8 length);
- some changes in the RefreshPage method to use this new method.

Sorry about that.