### PR TITLE
Fix typo inside saving routine for Raspberry Pi Zero

### DIFF
--- a/src/DiskImage.h
+++ b/src/DiskImage.h
@@ -117,7 +117,7 @@ public:
 		else
 		{
 			TestDirty(track, (dataOld & bitMask) != 0);
-			tracks[(track << 13) + byte] &= bitMask;
+			tracks[(track << 13) + byte] &= ~bitMask;
 		}
 #else
 		u8 dataOld = tracks[track][byte];


### PR DESCRIPTION
There's typo in saving routine which renders Pi1541 on Raspberry Pi Zero unable to save any disks.