### PR TITLE
fixed permanently disabled 1581 support

### DIFF
--- a/src/Pi1581.cpp
+++ b/src/Pi1581.cpp
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Pi1541. If not, see <http://www.gnu.org/licenses/>.
 
+#include "defs.h"
 #include "Pi1581.h"
 #include "iec_bus.h"
 #include "options.h"


### PR DESCRIPTION
define PI1581SUPPORT was always unknown within Pi1581.cpp. One way to fix this is to include defs.h