### PR TITLE
display 1581 rom name after mounting an d81 image on big screen

### DIFF
--- a/src/FileBrowser.cpp
+++ b/src/FileBrowser.cpp
@@ -1433,6 +1433,11 @@ void FileBrowser::ClearSelections()
 
 void FileBrowser::ShowDeviceAndROM()
 {
+	ShowDeviceAndROM( roms->ROMNames[roms->currentROMIndex] );
+}
+
+void FileBrowser::ShowDeviceAndROM( const char* ROMName )
+{
 	char buffer[256];
 	u32 textColour = RGBA(0, 0, 0, 0xff);
 	u32 bgColour = RGBA(0xff, 0xff, 0xff, 0xff);
@@ -1443,7 +1448,7 @@ void FileBrowser::ShowDeviceAndROM()
 	snprintf(buffer, 256, "Device %2d %*s\r\n"
 		, *deviceID
 		, roms->GetLongestRomNameLen()
-		, roms->ROMNames[roms->currentROMIndex]
+		, ROMName
 		);
 	screenMain->PrintText(false, x, y, buffer, textColour, bgColour);
 #endif

--- a/src/FileBrowser.h
+++ b/src/FileBrowser.h
@@ -187,6 +187,8 @@ public:
 	void ClearSelections();
 
 	void ShowDeviceAndROM();
+	void ShowDeviceAndROM( const char* ROMName );
+	
 
 	void ClearScreen();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -651,7 +651,7 @@ EmulatingMode BeginEmulating(FileBrowser* fileBrowser, const char* filenameForIc
 		{
 			pi1581.Insert(diskImage);
 			fileBrowser->DisplayDiskInfo(diskImage, filenameForIcon);
-			fileBrowser->ShowDeviceAndROM();
+			fileBrowser->ShowDeviceAndROM( roms.ROMName1581 );
 			return EMULATING_1581;
 		}
 		else


### PR DESCRIPTION
Maybe not very important but the rom name of the 1581 rom used was never displayed on the big screen (HDMI). There was always the active 1541 rom displayed.