### PR TITLE
fixed problem with error channel in native mode:

### DIFF
--- a/src/iec_commands.cpp
+++ b/src/iec_commands.cpp
@@ -163,7 +163,7 @@ void Error(u8 errorCode, u8 track = 0, u8 sector = 0)
 			msg = "WRITE ERROR";
 		break;
 		case ERROR_73_DOSVERSION:
-			sprintf(ErrorMessage, "%02d,PI1541 V%02d.%02d,%02d,%02d", errorCode,
+			snprintf(ErrorMessage, sizeof(ErrorMessage)-1, "%02d,PI1541 V%02d.%02d,%02d,%02d\r", errorCode,
 						versionMajor, versionMinor, track, sector);
 			return;
 		break;
@@ -187,7 +187,7 @@ void Error(u8 errorCode, u8 track = 0, u8 sector = 0)
 			DEBUG_LOG("EC=%d?\r\n", errorCode);
 		break;
 	}
-	sprintf(ErrorMessage, "%02d,%s,%02d,%02d", errorCode, msg, track, sector);
+	snprintf(ErrorMessage, sizeof(ErrorMessage)-1, "%02d,%s,%02d,%02d\r", errorCode, msg, track, sector);
 }
 
 static inline bool IsDirectory(FILINFO& filInfo)


### PR DESCRIPTION
One thing that me left really annoyed when using Pi1541 was that reading the error channel with Action Replay and others caused the system to run an endless loop after the full data was read. Today, I finally had an idea what could be causing this.

When you read the error channel on a 1541, you'll never get a typical "end of data" notification, but instead the stream starts over again sending "00, OK,00,00", and again, and again... So most (if not all) implementations read the buffer until they read $0d (the return charater) and then stop. When Pi1541 is not sending return, some garbage is read after the channel doesn't have any more data.

Goes half-way for a correct implementation by sending a $0d-byte after the message. It does not implement the "loop-over" of a typical commodore floppy drive, as I'm unsure if it would be worth the effort.

I also changed the sprintf to snprintf so the buffer will never be written out-of-bounds.