### PR TITLE
Fix dereference of uninitialized m_pVIA pointer

### DIFF
--- a/src/Drive.cpp
+++ b/src/Drive.cpp
@@ -344,10 +344,11 @@ extern "C"
 #define DISK_SWAP_CYCLES_NO_DISK 200000
 #define DISK_SWAP_CYCLES_DISK_INSERTING 400000
 
-Drive::Drive()
+Drive::Drive(m6522* pVIA)
 	: diskImage(0)
-	, m_pVIA(0)
+	, m_pVIA(pVIA)
 {
+	pVIA->GetPortB()->SetPortOut(this, OnPortOut);
 	srand(0x811c9dc5U);
 #if defined(EXPERIMENTALZERO)
 	localSeed = 0x811c9dc5U;

--- a/src/Drive.h
+++ b/src/Drive.h
@@ -37,13 +37,7 @@ inline int ceil(float num) {
 class Drive
 {
 public:
-	Drive();
-
-	void SetVIA(m6522* pVIA)
-	{
-		m_pVIA = pVIA;
-		pVIA->GetPortB()->SetPortOut(this, OnPortOut);
-	}
+	Drive(m6522* pVIA);
 
 	static void OnPortOut(void*, unsigned char status);
 

--- a/src/Pi1541.cpp
+++ b/src/Pi1541.cpp
@@ -161,6 +161,7 @@ void write6502ExtraRAM(u16 address, const u8 value)
 }
 
 Pi1541::Pi1541()
+	: drive(&VIA[1])
 {
 	VIA[0].ConnectIRQ(&m6502.IRQ);
 	VIA[1].ConnectIRQ(&m6502.IRQ);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1983,7 +1983,6 @@ extern "C"
 
 		GlobalSetDeviceID(deviceID);
 
-		pi1541.drive.SetVIA(&pi1541.VIA[1]);
 		pi1541.VIA[0].GetPortB()->SetPortOut(0, IEC_Bus::PortB_OnPortOut);
 		IEC_Bus::Initialise();
 		if (screenLCD)


### PR DESCRIPTION
On startup (before kernel_main), the global object pi1541 causes the Pi1541 constructor being called, which calls the Drive constructor, which calls Drive::Reset, which calls m_pVIA->InputCA1 with m_pVIA is still uninitialized.

Fix this by passing the pVIA object to Drive via its constructor already.