### PR TITLE
Add graphical disk visualization with real-time sector highlighting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ OBJS	= armc-start.o armc-cstartup.o armc-cstubs.o armc-cppstubs.o \
 	rpi-gpio.o rpi-interrupts.o dmRotary.o cache.o ff.o interrupt.o Keyboard.o performance.o \
 	Drive.o Pi1541.o DiskImage.o iec_bus.o iec_commands.o m6502.o m6522.o \
 	gcr.o prot.o lz.o emmc.o diskio.o options.o Screen.o SSD1306.o ScreenLCD.o \
-	Timer.o FileBrowser.o DiskCaddy.o ROMs.o InputMappings.o xga_font_data.o m8520.o wd177x.o Pi1581.o SpinLock.o
+	Timer.o FileBrowser.o DiskCaddy.o ROMs.o InputMappings.o xga_font_data.o m8520.o wd177x.o Pi1581.o SpinLock.o \
+	DiskVisualizer.o
 
 SRCDIR   = src
 OBJS    := $(addprefix $(SRCDIR)/, $(OBJS))

--- a/README.md
+++ b/README.md
@@ -42,3 +42,26 @@ This will build kernel.img
 
 
 In order to build the Commodore programs from the `CBM-FileBrowser_v1.6/sources/` directory, you'll need to install the ACME cross assembler, which is available at https://github.com/meonwax/acme/
+
+Disk Visualization
+------------------
+
+The disk info screen now displays a graphical floppy disk visualization that
+shows real-time drive activity. When a D64 disk image is loaded, the old
+rectangular BAM grid is replaced with a circular disk rendering:
+
+- **Track/sector layout**: Concentric rings represent tracks (outermost = track 1). Each ring is divided into sectors based on the D64 zone layout (21/19/18/17 sectors per track).
+- **BAM coloring**: Sectors are colored based on the Block Availability Map — green for allocated (has data), black for free, and cyan for directory track 18.
+- **Active sector highlighting**: When the drive LED is on (indicating a read/write), the sector currently under the head is highlighted in red.
+- **Read head**: A small carriage on the south side of the disk moves vertically to track the current head position. The current track number is displayed inside the head.
+- **Signal graph**: The existing IEC bus signal graph (ATN, DATA, CLOCK) continues to render across the bottom of the screen below the disk.
+
+The visualization uses integer-only math (`int_sqrt`, `int_atan2`) to avoid
+floating-point dependencies on the bare-metal Raspberry Pi kernel.
+
+### Files
+
+- `src/DiskVisualizer.h` — Class interface and color constants
+- `src/DiskVisualizer.cpp` — Rendering engine (full disk render + lightweight head updates)
+- `src/FileBrowser.cpp` — Layout integration in `DisplayDiskInfo()`
+- `src/main.cpp` — Real-time `UpdateHead()` hook in `UpdateScreen()`

--- a/src/DiskCaddy.cpp
+++ b/src/DiskCaddy.cpp
@@ -28,8 +28,8 @@ extern "C"
 
 extern u8 deviceID;
 
-static const u32 screenPosXCaddySelections = 240;
-static const u32 screenPosYCaddySelections = 280;
+static const u32 screenPosXCaddySelections = 0;
+static const u32 screenPosYCaddySelections = 40 * 16 + 10 - 60;
 static char buffer[256] = { 0 };
 static u32 white = RGBA(0xff, 0xff, 0xff, 0xff);
 static u32 red = RGBA(0xff, 0, 0, 0xff);

--- a/src/DiskVisualizer.cpp
+++ b/src/DiskVisualizer.cpp
@@ -1,0 +1,488 @@
+// Pi1541 - Disk Visualizer Implementation
+// Uses ScreenBase drawing primitives to render floppy disk visualization.
+// Integer-only math to avoid floating point linking issues on bare metal.
+//
+// RenderDisk: full render with BAM, called once when disk loaded.
+// UpdateHead: lightweight head-only update, called from UpdateScreen loop.
+
+#include "DiskVisualizer.h"
+#include "types.h"
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Integer square root (no floating point)
+static int int_sqrt(int x) {
+    if (x <= 0) return 0;
+    int r = 0;
+    int bit = 1 << 30;
+    while (bit > x) bit >>= 2;
+    while (bit != 0) {
+        if (x >= r + bit) {
+            x -= r + bit;
+            r = (r >> 1) + bit;
+        } else {
+            r >>= 1;
+        }
+        bit >>= 2;
+    }
+    return r;
+}
+
+// Integer atan2: returns angle in 0-255 range (0 = east, 64 = south, 128 = west, 192 = north)
+static int int_atan2(int y, int x) {
+    if (x == 0 && y == 0) return 0;
+    if (x == 0) return (y > 0) ? 64 : 192;
+    if (y == 0) return (x > 0) ? 0 : 128;
+
+    int abs_y = y < 0 ? -y : y;
+    int abs_x = x < 0 ? -x : x;
+
+    int angle;
+    if (abs_y < abs_x)
+        angle = (abs_y * 32) / abs_x;
+    else
+        angle = 64 - ((abs_x * 32) / abs_y);
+
+    if (x < 0) angle = 128 - angle;
+    if (y < 0) angle = 256 - angle;
+
+    return angle & 255;
+}
+
+// Color constants
+const u32 DiskVisualizer::COLOR_EMPTY       = RGBA(10, 10, 10, 255);
+const u32 DiskVisualizer::COLOR_DATA        = RGBA(40, 200, 40, 255);
+const u32 DiskVisualizer::COLOR_ACTIVE      = RGBA(255, 0, 0, 255);
+const u32 DiskVisualizer::COLOR_DIRECTORY   = RGBA(60, 180, 220, 255);
+const u32 DiskVisualizer::COLOR_DISK_BG     = RGBA(50, 35, 20, 255);
+const u32 DiskVisualizer::COLOR_DISK_LABEL  = RGBA(220, 210, 180, 255);
+const u32 DiskVisualizer::COLOR_DISK_HUB    = RGBA(160, 160, 170, 255);
+const u32 DiskVisualizer::COLOR_HEAD        = RGBA(220, 30, 30, 255);
+const u32 DiskVisualizer::COLOR_HEAD_GLOW   = RGBA(255, 140, 30, 255);
+const u32 DiskVisualizer::COLOR_HEAD_ARM    = RGBA(80, 80, 90, 255);
+const u32 DiskVisualizer::COLOR_TRACK_LABEL = RGBA(255, 255, 255, 255);
+const u32 DiskVisualizer::COLOR_SECTOR_IDLE = RGBA(100, 100, 100, 255);
+const u32 DiskVisualizer::COLOR_SECTOR_GAP  = RGBA(35, 25, 12, 255);
+
+DiskVisualizer::DiskVisualizer()
+    : m_x(0), m_y(0), m_width(0), m_height(0)
+    , m_cx(0), m_cy(0), m_maxRadius(0)
+    , m_dataInnerR(0), m_dataOuterR(0)
+    , m_hubRadius(0), m_labelRadius(0)
+    , m_trackCount(0), m_trackWidth(0), m_headWidth(0)
+    , m_diskImage(0), m_oldHalfTrack(-1), m_oldLedOn(false)
+    , m_initialized(false)
+    , m_lastHighlightTrack(-1), m_lastHighlightSector(-1)
+    , m_lastHighlightActive(false)
+{
+    memset(m_sectorUsed, 0, sizeof(m_sectorUsed));
+    memset(m_bitsPerTrack, 0, sizeof(m_bitsPerTrack));
+    memset(m_sectorsPerTrack, 0, sizeof(m_sectorsPerTrack));
+}
+
+void DiskVisualizer::Reset()
+{
+    m_initialized = false;
+    m_oldHalfTrack = -1;
+    m_oldLedOn = false;
+    m_diskImage = 0;
+    m_lastHighlightTrack = -1;
+    m_lastHighlightSector = -1;
+    m_lastHighlightActive = false;
+    memset(m_sectorUsed, 0, sizeof(m_sectorUsed));
+    memset(m_bitsPerTrack, 0, sizeof(m_bitsPerTrack));
+    memset(m_sectorsPerTrack, 0, sizeof(m_sectorsPerTrack));
+}
+
+void DiskVisualizer::FillCircle(ScreenBase* screen, int cx, int cy, int radius, u32 color)
+{
+    for (int dy = -radius; dy <= radius; dy++) {
+        int dx = int_sqrt(radius * radius - dy * dy);
+        screen->DrawRectangle(cx - dx, cy + dy, cx + dx, cy + dy, color);
+    }
+}
+
+// Map a half-track to a Y position on screen (head is on south side)
+int DiskVisualizer::HeadYForHalfTrack(int halfTrack) const
+{
+    if (m_trackCount <= 1) return m_cy + m_dataOuterR;
+    // Full track index (0-based), with half-track interpolation
+    // halfTrack 0 = outermost (track 1), higher = innermost
+    int range = m_dataOuterR - m_dataInnerR;
+    // Map halfTrack to a position: 0 = outer, (trackCount*2-2) = inner
+    int maxHT = (m_trackCount - 1) * 2;
+    if (maxHT <= 0) maxHT = 1;
+    int offset = (halfTrack * range) / maxHT;
+    return m_cy + m_dataOuterR - offset;
+}
+
+// Get color for a given track/sector based on BAM cache
+u32 DiskVisualizer::GetSectorColor(int track, int sector) const
+{
+    if (track == 17) { // Directory track (track 18, 0-indexed = 17)
+        return m_sectorUsed[track][sector] ? COLOR_DIRECTORY : COLOR_EMPTY;
+    }
+    return m_sectorUsed[track][sector] ? COLOR_DATA : COLOR_EMPTY;
+}
+
+// Redraw the narrow vertical strip where the head arm lives (erases old head)
+// No blanking rectangle — each pixel is drawn directly to avoid flicker
+void DiskVisualizer::RedrawHeadStrip(ScreenBase* screen, int highlightTrack,
+                                     int highlightSector, bool highlightActive)
+{
+    int stripHalfW = m_headWidth + 4;
+    int stripLeft = m_cx - stripHalfW - 1;
+    int stripRight = m_cx + stripHalfW + 1;
+    int stripTop = m_cy + m_dataInnerR - 4;
+    int stripBottom = m_cy + m_dataOuterR + 6;
+
+    for (int py = stripTop; py <= stripBottom; ++py) {
+        int dy = py - m_cy;
+        for (int px = stripLeft; px <= stripRight; ++px) {
+            int dx = px - m_cx;
+            int dist = int_sqrt(dx * dx + dy * dy);
+
+            // Outside the data ring — draw disk background
+            if (dist < m_dataInnerR || dist > m_dataOuterR) {
+                screen->PlotPixel(px, py, COLOR_DISK_BG);
+                continue;
+            }
+
+            int fromOuter = m_dataOuterR - dist;
+            int t = fromOuter / m_trackWidth;
+            if (t < 0 || t >= m_trackCount) {
+                screen->PlotPixel(px, py, COLOR_DISK_BG);
+                continue;
+            }
+
+            int trackTop = t * m_trackWidth;
+            int trackBot = trackTop + m_trackWidth;
+            if (fromOuter < trackTop + 1 || fromOuter > trackBot - 1) {
+                screen->PlotPixel(px, py, COLOR_SECTOR_GAP);
+                continue;
+            }
+
+            int spt = m_sectorsPerTrack[t] > 0 ? m_sectorsPerTrack[t] : DiskImage::SectorsPerTrackD64(t);
+            if (spt <= 0) spt = 17;
+
+            int angle = int_atan2(dy, dx);
+            int sectorAngle = 256 / spt;
+            int sectorIndex = angle / sectorAngle;
+            if (sectorIndex < 0) sectorIndex = 0;
+            if (sectorIndex >= spt) sectorIndex = spt - 1;
+
+            int sectorStart = sectorIndex * sectorAngle;
+            int sectorEnd = sectorStart + sectorAngle;
+            int gap = sectorAngle / 10;
+            if (angle < sectorStart + gap || angle > sectorEnd - gap) {
+                screen->PlotPixel(px, py, COLOR_SECTOR_GAP);
+                continue;
+            }
+
+            u32 baseColor = GetSectorColor(t, sectorIndex);
+            if (!baseColor) baseColor = COLOR_SECTOR_IDLE;
+
+            if (highlightActive && t == highlightTrack) {
+                if (highlightSector >= 0) {
+                    if (sectorIndex == highlightSector)
+                        screen->PlotPixel(px, py, COLOR_ACTIVE);
+                    else
+                        screen->PlotPixel(px, py, baseColor);
+                } else {
+                    if (baseColor != COLOR_EMPTY)
+                        screen->PlotPixel(px, py, COLOR_ACTIVE);
+                    else
+                        screen->PlotPixel(px, py, baseColor);
+                }
+            } else {
+                screen->PlotPixel(px, py, baseColor);
+            }
+        }
+    }
+}
+
+// Draw the read head carriage, arm, and track number inside the head
+void DiskVisualizer::DrawHeadAt(ScreenBase* screen, int halfTrack, bool active)
+{
+    int headY = HeadYForHalfTrack(halfTrack);
+    int headX = m_cx;
+    int headTop = m_cy + m_dataInnerR - 2;
+    int headBottom = m_cy + m_dataOuterR + 4;
+
+    // Head carriage sized to fit 2-digit track number (8x8 font)
+    int carriageHalfH = 5;  // 11px tall total, enough for 8px font + padding
+    int carriageHalfW = Max((u32)m_headWidth, (u32)9); // at least 18px wide for 2 chars
+
+    // Head arm (vertical rail)
+    screen->DrawRectangle(headX - 1, headTop, headX + 1, headBottom, COLOR_HEAD_ARM);
+
+    // Glow when active (draw BEHIND carriage)
+    if (active) {
+        screen->DrawRectangle(headX - carriageHalfW - 2, headY - carriageHalfH - 2,
+                              headX + carriageHalfW + 2, headY + carriageHalfH + 2,
+                              COLOR_HEAD_GLOW);
+    }
+
+    // Head carriage
+    screen->DrawRectangle(headX - carriageHalfW, headY - carriageHalfH,
+                          headX + carriageHalfW, headY + carriageHalfH,
+                          COLOR_HEAD);
+
+    // Track number inside the head carriage
+    char buf[4];
+    int fullTrack = (halfTrack >> 1) + 1;
+    snprintf(buf, sizeof(buf), "%d", fullTrack);
+
+    // Center the text inside the carriage
+    int textW = (fullTrack >= 10) ? 16 : 8; // 1 or 2 chars * 8px
+    int textX = headX - textW / 2;
+    int textY = headY - 4; // vertically center 8px font in carriage
+
+    screen->PrintText(false, textX, textY, buf, COLOR_TRACK_LABEL, COLOR_HEAD);
+}
+
+// DrawTrackLabel is no longer used (track number is now inside the head)
+void DiskVisualizer::DrawTrackLabel(ScreenBase* screen, int halfTrack, bool active)
+{
+    (void)screen; (void)halfTrack; (void)active;
+}
+
+void DiskVisualizer::DrawTrackSectors(ScreenBase* screen, int trackIndex,
+                                      int highlightSector, bool highlightActive)
+{
+    int outerR = m_dataOuterR - trackIndex * m_trackWidth;
+    int innerR = outerR - m_trackWidth;
+    if (outerR <= innerR) return;
+
+    int dyStart = -outerR;
+    int dyEnd = outerR;
+
+    int spt = m_sectorsPerTrack[trackIndex];
+    if (spt <= 0) spt = DiskImage::SectorsPerTrackD64(trackIndex);
+    if (spt <= 0) spt = 17;
+
+    int sectorAngle = 256 / spt;
+    int gap = sectorAngle / 10;
+
+    for (int dy = dyStart; dy <= dyEnd; dy++) {
+        int py = m_cy + dy;
+        int outerDx = int_sqrt(outerR * outerR - dy * dy);
+        int innerDx = 0;
+        if (abs(dy) < innerR)
+            innerDx = int_sqrt(innerR * innerR - dy * dy);
+
+        for (int dx = -outerDx; dx <= outerDx; dx++) {
+            if (abs(dx) < innerDx)
+                continue;
+
+            int px = m_cx + dx;
+            int dist = int_sqrt(dx * dx + dy * dy);
+            if (dist < innerR + 1 || dist > outerR - 1)
+                continue;
+
+            int angle = int_atan2(dy, dx);
+            int sectorIndex = angle / sectorAngle;
+            if (sectorIndex < 0) sectorIndex = 0;
+            if (sectorIndex >= spt) sectorIndex = spt - 1;
+
+            int sectorStart = sectorIndex * sectorAngle;
+            int sectorEnd = sectorStart + sectorAngle;
+            if (angle < sectorStart + gap || angle > sectorEnd - gap)
+            {
+                screen->PlotPixel(px, py, COLOR_SECTOR_GAP);
+                continue;
+            }
+
+            u32 baseColor = GetSectorColor(trackIndex, sectorIndex);
+            if (!baseColor) baseColor = COLOR_SECTOR_IDLE;
+
+            if (highlightActive) {
+                if (highlightSector >= 0) {
+                    if (sectorIndex == highlightSector)
+                        screen->PlotPixel(px, py, COLOR_ACTIVE);
+                    else
+                        screen->PlotPixel(px, py, baseColor);
+                } else {
+                    if (baseColor != COLOR_EMPTY)
+                        screen->PlotPixel(px, py, COLOR_ACTIVE);
+                    else
+                        screen->PlotPixel(px, py, baseColor);
+                }
+            } else {
+                screen->PlotPixel(px, py, baseColor);
+            }
+        }
+    }
+}
+
+// ---- Full disk render (called once from DisplayDiskInfo) ----
+void DiskVisualizer::RenderDisk(ScreenBase* screen, int x, int y, int width, int height,
+                                DiskImage* diskImage)
+{
+    if (!diskImage || width <= 0 || height <= 0) return;
+
+    // Store geometry
+    m_x = x;
+    m_y = y;
+    m_width = width;
+    m_height = height;
+    m_diskImage = diskImage;
+
+    m_trackCount = diskImage->LastTrackUsed();
+    if (m_trackCount <= 0) m_trackCount = 35;
+    // LastTrackUsed returns half-track count; convert to full tracks
+    m_trackCount = m_trackCount >> 1;
+    if (m_trackCount <= 0) m_trackCount = 35;
+    if (m_trackCount > 42) m_trackCount = 42;
+
+    m_cx = x + width / 2;
+    m_cy = y + height / 2 - screen->ScaleY(12);
+    int availableRadius = Min((u32)width, (u32)height) / 2;
+    m_maxRadius = availableRadius - screen->ScaleY(40);
+    if (m_maxRadius < 20) return;
+
+    m_hubRadius = m_maxRadius / 8;
+    m_labelRadius = m_maxRadius / 4;
+    m_dataInnerR = m_labelRadius + 4;
+    m_dataOuterR = m_maxRadius - 4;
+    m_trackWidth = (m_dataOuterR - m_dataInnerR) / m_trackCount;
+    if (m_trackWidth < 1) m_trackWidth = 1;
+    m_headWidth = Max((u32)4, (u32)((m_dataOuterR - m_dataInnerR) / 30));
+
+    // Read BAM from disk image
+    memset(m_sectorUsed, 0, sizeof(m_sectorUsed));
+    unsigned char bamBuffer[260];
+    if (diskImage->GetDecodedSector(18, 0, bamBuffer)) {
+        int lastTrackUsed = m_trackCount;
+
+        // Guess 40-track format
+        int guess40 = 0;
+        if (lastTrackUsed >= 39) {
+            int dolphin_sum = 0, speeddos_sum = 0;
+            for (int i = 0; i < 20; i++) {
+                dolphin_sum += bamBuffer[0xac + i];
+                speeddos_sum += bamBuffer[0xc0 + i];
+            }
+            if (dolphin_sum == 0 && speeddos_sum != 0) guess40 = 0xc0;
+            if (dolphin_sum != 0 && speeddos_sum == 0) guess40 = 0xac;
+        }
+
+        for (int bamTrack = 0; bamTrack < lastTrackUsed && bamTrack < 42; ++bamTrack) {
+            int bamOffset;
+            if (bamTrack >= 35)
+                bamOffset = guess40;
+            else
+                bamOffset = BAM_OFFSET;
+
+            if (!bamOffset) continue;
+
+            int spt = DiskImage::SectorsPerTrackD64(bamTrack);
+            for (int bit = 0; bit < spt && bit < 24; bit++) {
+                u32 bits = bamBuffer[bamOffset + 1 + (bit >> 3) + bamTrack * BAM_ENTRY_SIZE];
+                bool isFree = (bits & (1 << (bit & 0x7))) != 0;
+                m_sectorUsed[bamTrack][bit] = !isFree; // true = allocated/has data
+            }
+        }
+    }
+
+    // 1. Draw disk surface
+    FillCircle(screen, m_cx, m_cy, m_maxRadius, COLOR_DISK_BG);
+
+    // 2. Draw track/sector data
+    for (int t = 0; t < m_trackCount; ++t)
+    {
+        if (t < 42)
+        {
+            m_bitsPerTrack[t] = diskImage->BitsInTrack(t << 1);
+            m_sectorsPerTrack[t] = DiskImage::SectorsPerTrackD64(t);
+        }
+        DrawTrackSectors(screen, t, -1, false);
+    }
+
+    // 3. Draw center label
+    FillCircle(screen, m_cx, m_cy, m_labelRadius, COLOR_DISK_LABEL);
+
+    // 4. Draw hub
+    FillCircle(screen, m_cx, m_cy, m_hubRadius, COLOR_DISK_HUB);
+
+    // 5. Draw hub hole
+    FillCircle(screen, m_cx, m_cy, m_hubRadius / 2, RGBA(20, 20, 25, 255));
+
+    m_oldHalfTrack = -1;
+    m_oldLedOn = false;
+    m_initialized = true;
+    m_lastHighlightTrack = -1;
+    m_lastHighlightSector = -1;
+    m_lastHighlightActive = false;
+
+    // 6. Draw initial head at track 1 (halfTrack 0)
+    DrawHeadAt(screen, 0, false);
+    m_oldHalfTrack = 0;
+}
+
+// ---- Lightweight head update (called from UpdateScreen) ----
+void DiskVisualizer::UpdateHead(ScreenBase* screen, unsigned int halfTrack,
+                                unsigned int headBitOffset, bool ledOn)
+{
+    if (!m_initialized || !screen) return;
+
+    int trackIndex = (int)(halfTrack >> 1);
+    if (trackIndex < 0) trackIndex = 0;
+    if (trackIndex >= m_trackCount) trackIndex = m_trackCount - 1;
+
+    int bitsInTrack = (trackIndex >= 0 && trackIndex < 42) ? m_bitsPerTrack[trackIndex] : 0;
+    if (!bitsInTrack && m_diskImage)
+        bitsInTrack = m_diskImage->BitsInTrack(trackIndex << 1);
+
+    int sectorIndex = -1;
+    if (bitsInTrack > 0)
+    {
+        int spt = m_sectorsPerTrack[trackIndex];
+        if (spt <= 0) spt = DiskImage::SectorsPerTrackD64(trackIndex);
+        if (spt > 0)
+        {
+            // Calculate sector based on bit position within track
+            // Each sector occupies bitsInTrack/spt bits
+            int bitsPerSector = bitsInTrack / spt;
+            sectorIndex = (headBitOffset % bitsInTrack) / bitsPerSector;
+            if (sectorIndex >= spt) sectorIndex = spt - 1;
+        }
+    }
+
+    bool highlightActive = ledOn;
+
+    bool needsRedraw = (int)halfTrack != m_oldHalfTrack || ledOn != m_oldLedOn ||
+                       trackIndex != m_lastHighlightTrack ||
+                       sectorIndex != m_lastHighlightSector ||
+                       highlightActive != m_lastHighlightActive;
+
+    if (!needsRedraw)
+        return;
+
+    // If highlighted track/sector changed, redraw full track rings
+    if (m_lastHighlightTrack >= 0 && m_lastHighlightTrack < m_trackCount &&
+        (m_lastHighlightTrack != trackIndex ||
+         m_lastHighlightSector != sectorIndex ||
+         m_lastHighlightActive != highlightActive))
+    {
+        // Restore old track to normal (no highlight)
+        DrawTrackSectors(screen, m_lastHighlightTrack, -1, false);
+    }
+
+    // Draw new highlighted track with active sector
+    if (trackIndex >= 0 && trackIndex < m_trackCount)
+        DrawTrackSectors(screen, trackIndex, sectorIndex, highlightActive);
+
+    // Erase old head by redrawing the strip of disk under it
+    RedrawHeadStrip(screen, trackIndex, sectorIndex, highlightActive);
+
+    // Draw new head (includes track number inside carriage)
+    DrawHeadAt(screen, halfTrack, ledOn);
+
+    m_oldHalfTrack = halfTrack;
+    m_oldLedOn = ledOn;
+    m_lastHighlightTrack = trackIndex;
+    m_lastHighlightSector = sectorIndex;
+    m_lastHighlightActive = highlightActive;
+}

--- a/src/DiskVisualizer.h
+++ b/src/DiskVisualizer.h
@@ -1,0 +1,90 @@
+// Pi1541 - Disk Visualizer for Primary Screen
+// Renders a graphical floppy disk with track/sector visualization
+// and read head animation using the Pi1541's Screen drawing primitives.
+//
+// Usage:
+//   1. Call RenderDisk() once when a disk is loaded (from DisplayDiskInfo)
+//   2. Call UpdateHead() from UpdateScreen() when track or LED state changes
+//      for real-time read head movement and sector access highlighting.
+
+#ifndef DISK_VISUALIZER_H
+#define DISK_VISUALIZER_H
+
+#include "ScreenBase.h"
+#include "DiskImage.h"
+
+class DiskVisualizer {
+public:
+    DiskVisualizer();
+
+    // Full render: draws the complete disk with BAM-based sector coloring.
+    // Call once when a disk image is loaded.
+    void RenderDisk(ScreenBase* screen, int x, int y, int width, int height,
+                    DiskImage* diskImage);
+
+    // Lightweight update: moves the read head and highlights the active sector.
+    // Call from UpdateScreen() when halfTrack or LED state changes.
+    // halfTrack: raw half-track value from Drive::Track() (0-69)
+    // ledOn: true if drive LED is on (indicates active read/write)
+    void UpdateHead(ScreenBase* screen, unsigned int halfTrack,
+                    unsigned int headBitOffset, bool ledOn);
+
+    // Check if a disk has been rendered (geometry is valid)
+    bool IsInitialized() const { return m_initialized; }
+
+    // Reset state (e.g. when disk is ejected)
+    void Reset();
+
+private:
+    // Drawing helpers
+    void FillCircle(ScreenBase* screen, int cx, int cy, int radius, u32 color);
+    void RedrawHeadStrip(ScreenBase* screen, int highlightTrack,
+                         int highlightSector, bool highlightActive);
+    void DrawHeadAt(ScreenBase* screen, int halfTrack, bool active);
+    void DrawTrackLabel(ScreenBase* screen, int halfTrack, bool active);
+    void DrawTrackSectors(ScreenBase* screen, int trackIndex,
+                          int highlightSector, bool highlightActive);
+    u32 GetSectorColor(int track, int sector) const;
+    int HeadYForHalfTrack(int halfTrack) const;
+
+    // Stored geometry from RenderDisk
+    int m_x, m_y, m_width, m_height;
+    int m_cx, m_cy;
+    int m_maxRadius;
+    int m_dataInnerR, m_dataOuterR;
+    int m_hubRadius, m_labelRadius;
+    int m_trackCount;
+    int m_trackWidth;
+    int m_headWidth;
+
+    // State tracking
+    DiskImage* m_diskImage;
+    int m_oldHalfTrack;
+    bool m_oldLedOn;
+    bool m_initialized;
+    int m_lastHighlightTrack;
+    int m_lastHighlightSector;
+    bool m_lastHighlightActive;
+
+    // BAM cache: true = sector is allocated (has data)
+    bool m_sectorUsed[42][24];
+    int m_bitsPerTrack[42];
+    int m_sectorsPerTrack[42];
+
+    // Color constants (RGBA format)
+    static const u32 COLOR_EMPTY;
+    static const u32 COLOR_DATA;
+    static const u32 COLOR_ACTIVE;
+    static const u32 COLOR_DIRECTORY;
+    static const u32 COLOR_DISK_BG;
+    static const u32 COLOR_DISK_LABEL;
+    static const u32 COLOR_DISK_HUB;
+    static const u32 COLOR_HEAD;
+    static const u32 COLOR_HEAD_GLOW;
+    static const u32 COLOR_HEAD_ARM;
+    static const u32 COLOR_TRACK_LABEL;
+    static const u32 COLOR_SECTOR_IDLE;
+    static const u32 COLOR_SECTOR_GAP;
+};
+
+#endif // DISK_VISUALIZER_H

--- a/src/FileBrowser.cpp
+++ b/src/FileBrowser.cpp
@@ -17,6 +17,7 @@
 // along with Pi1541. If not, see <http://www.gnu.org/licenses/>.
 
 #include "FileBrowser.h"
+#include "DiskVisualizer.h"
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
@@ -1477,12 +1478,10 @@ void FileBrowser::ShowDeviceAndROM( const char* ROMName )
 void FileBrowser::DisplayDiskInfo(DiskImage* diskImage, const char* filenameForIcon)
 {
 #if not defined(EXPERIMENTALZERO)
-	// Ideally we should not have to load the entire disk to read the directory.
 	static const char* fileTypes[]=
 	{
 		"DEL", "SEQ", "PRG", "USR", "REL", "UKN", "UKN", "UKN"
 	};
-	// Decode the BAM
 	unsigned track = 18;
 	unsigned sectorNo = 0;
 	char name[17] = { 0 };
@@ -1495,66 +1494,39 @@ void FileBrowser::DisplayDiskInfo(DiskImage* diskImage, const char* filenameForI
 	u32 textColour = palette[VIC2_COLOUR_INDEX_LBLUE];
 	u32 bgColour = palette[VIC2_COLOUR_INDEX_BLUE];
 
-	u32 usedColour = palette[VIC2_COLOUR_INDEX_RED];
-	u32 freeColour = palette[VIC2_COLOUR_INDEX_LGREEN];
-	u32 thisColour = 0;
-	u32 BAMOffsetX = screenMain->ScaleX(400);
-
-	u32 bmBAMOffsetX = screenMain->ScaleX(1024) - PNG_WIDTH;
-	u32 x_px = 0;
-	u32 y_px = 0;
-
 	ClearScreen();
 
-	if (options.DisplayTracks())
-	{
-		for (track = 0; track < HALF_TRACK_COUNT; track += 2)
-		{
-			int yoffset = screenMain->ScaleY(400);
-			unsigned index;
-			unsigned length = diskImage->TrackLength(track);
-			unsigned countSync = 0;
+	// Layout: directory listing top-left, graphical disk visualization right.
+	// The disk visualization replaces the old rectangular BAM grid with a
+	// circular floppy-disk rendering that shows track/sector usage from the BAM
+	// and highlights the active sector during emulation.
+	int screenWidth = screenMain->Width();
+	int screenHeight = screenMain->Height();
 
-			u8 shiftReg = 0;
-			for (index = 0; index < length / 8; ++index)
-			{
-				RGBA colour;
-				unsigned count1s = 0;
-				bool sync = false;
+	// Directory area: left 25% of screen
+	int dirWidth = screenWidth / 4;
+	int dirHeight = screenHeight - 40;
 
-				int bit;
+	// Disk visualization area: right 75%, with bottom margin for signal graph
+	int diskX = dirWidth;
+	int diskMarginTop = screenMain->ScaleY(8);
+	int diskMarginBottom = screenMain->ScaleY(160);
+	if (diskMarginBottom < 120) diskMarginBottom = 120;
+	int diskY = diskMarginTop;
+	int diskWidth = screenWidth - dirWidth;
+	int diskHeight = screenHeight - diskMarginTop - diskMarginBottom;
+	if (diskHeight < 80) diskHeight = 80;
 
-				for (bit = 0; bit < 64; ++bit)
-				{
-					if (bit % 8 == 0)
-						shiftReg = diskImage->GetNextByte(track, index * 8 + bit / 8);
+	int nameY = screenHeight - 40;
 
-					if (shiftReg & 0x80)
-					{
-						count1s++;
-						countSync++;
-						if (countSync == 10)
-							sync = true;
-					}
-					else
-					{
-						countSync = 0;
-					}
-					shiftReg <<= 1;
-				}
+	// Render the graphical disk visualization (full render with BAM data).
+	// The global diskVisualizer is shared with UpdateScreen() which calls
+	// UpdateHead() to animate the read head and highlight sectors in real time.
+	extern DiskVisualizer diskVisualizer;
+	diskVisualizer.RenderDisk(screenMain, diskX, diskY, diskWidth, diskHeight,
+	                          diskImage);
 
-				if (sync)
-					colour = RGBA(0xff, 0x00, 0x00, 0xFF);
-				else
-					colour = RGBA(0x00, (unsigned char)((float)count1s / 64.0f * 255.0f), 0x00, 0xFF);
-
-				screenMain->DrawRectangle(index, (track >> 1) * 4 + yoffset, index + 1, (track >> 1) * 4 + 4 + yoffset, colour);
-			}
-		}
-	}
-
-	track = 18;
-
+	// Render directory listing in top-left quadrant
 	if (diskImage->GetDecodedSector(track, sectorNo, buffer))
 	{
 		track = buffer[0];
@@ -1579,11 +1551,7 @@ void FileBrowser::DisplayDiskInfo(DiskImage* diskImage, const char* filenameForI
 		int bamOffset = BAM_OFFSET;
 		int guess40 = 0;
 
-		x_px = bmBAMOffsetX;
-		int x_size = PNG_WIDTH/lastTrackUsed;
-		int y_size = PNG_HEIGHT/21;
-
-// try to guess the 40 track format
+		// try to guess the 40 track format
 		if (lastTrackUsed == 39)
 		{
 			int dolphin_sum = 0;
@@ -1597,12 +1565,7 @@ void FileBrowser::DisplayDiskInfo(DiskImage* diskImage, const char* filenameForI
 				guess40 = 0xc0;
 			if ( dolphin_sum != 0 && speeddos_sum == 0)
 				guess40 = 0xac;
-
-// debugging
-//snprintf(bufferOut, 128, "LTU %d dd %d sd %d g40 %d", lastTrackUsed, dolphin_sum, speeddos_sum, guess40);
-//screenMain->PrintText(false, x_px, PNG_HEIGHT+30, bufferOut, textColour, bgColour);
 		}
-
 
 		for (bamTrack = 0; bamTrack <= lastTrackUsed; ++bamTrack)
 		{
@@ -1613,29 +1576,6 @@ void FileBrowser::DisplayDiskInfo(DiskImage* diskImage, const char* filenameForI
 
 			if (bamOffset && (bamTrack + 1) != 18)
 				blocksFree += buffer[bamOffset + bamTrack * BAM_ENTRY_SIZE];
-
-			y_px = 0;
-			for (u32 bit = 0; bit < DiskImage::SectorsPerTrackD64(bamTrack); bit++)
-			{
-				u32 bits = buffer[bamOffset + 1 + (bit >> 3) + bamTrack * BAM_ENTRY_SIZE];
-
-				if (!guess40 && bamTrack>= 35)
-					thisColour = 0;
-				else if (bits & (1 << (bit & 0x7)))
-					thisColour = freeColour;
-				else
-					thisColour = usedColour;
-
-// highight track 18
-				if ((bamTrack + 1) == 18)
-					screenMain->DrawRectangle(x_px, y_px, x_px+x_size, y_px+y_size, textColour);
-
-				screenMain->DrawRectangle(x_px+1, y_px+1, x_px+x_size-1, y_px+y_size-1, thisColour);
-
-				y_px += y_size;
-				bits <<= 1;
-			}
-			x_px += x_size;
 		}
 
 		x = 0;
@@ -1654,7 +1594,7 @@ void FileBrowser::DisplayDiskInfo(DiskImage* diskImage, const char* filenameForI
 			unsigned sectorPrev = 0xff;
 			bool complete = false;
 			// Blocks 1 through 19 on track 18 contain the file entries. The first two bytes of a block point to the next directory block with file entries. If no more directory blocks follow, these bytes contain $00 and $FF, respectively.
-			while (!complete)
+			while (!complete && y < dirHeight - fontHeight * 2)
 			{
 				//DEBUG_LOG("track %d sector %d\r\n", track, sectorNo);
 				if (diskImage->GetDecodedSector(track, sectorNo, buffer))
@@ -1673,7 +1613,7 @@ void FileBrowser::DisplayDiskInfo(DiskImage* diskImage, const char* filenameForI
 
 					int entry;
 					int entryOffset = 2;
-					for (entry = 0; entry < 8; ++entry)
+					for (entry = 0; entry < 8 && y < dirHeight - fontHeight * 2; ++entry)
 					{
 						bool done = true;
 						for (int i = 0; i < 0x1d; ++i)
@@ -1729,6 +1669,14 @@ void FileBrowser::DisplayDiskInfo(DiskImage* diskImage, const char* filenameForI
 		snprintf(bufferOut, 128, "%d BLOCKS FREE.\r\n", blocksFree);
 		screenMain->PrintText(true, x, y, bufferOut, textColour, bgColour);
 		y += fontHeight;
+	}
+
+	// Display disk name at bottom-left
+	x = 0;
+	y = nameY;
+	if (diskImage->GetName()) {
+		snprintf(bufferOut, 128, "DISK: %s", diskImage->GetName());
+		screenMain->PrintText(true, x, y, bufferOut, palette[VIC2_COLOUR_INDEX_WHITE], bgColour);
 	}
 
 	DisplayStatusBar();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,6 +43,7 @@ extern "C"
 #include "FileBrowser.h"
 #include "ScreenLCD.h"
 #include "SpinLock.h"
+#include "DiskVisualizer.h"
 
 #include "logo.h"
 #include "sample.h"
@@ -75,13 +76,6 @@ static const u8 snoopBackCommand[] = {
 static int snoopIndex = 0;
 static int snoopPC = 0;
 
-enum EmulatingMode
-{
-	IEC_COMMANDS,
-	EMULATING_1541,
-	EMULATING_1581
-};
-
 volatile EmulatingMode emulating;
 
 typedef void(*func_ptr)();
@@ -107,6 +101,7 @@ Pi1581 pi1581;
 #endif
 CEMMCDevice	m_EMMC;
 Screen screen;
+DiskVisualizer diskVisualizer;
 ScreenLCD* screenLCD = 0;
 Options options;
 const char* fileBrowserSelectedName;
@@ -569,6 +564,14 @@ void UpdateScreen()
 		if (emulating == EMULATING_1541)
 		{
 			track = pi1541.drive.Track();
+
+			// Update disk visualizer head in real-time (it tracks its own state internally)
+			if (diskVisualizer.IsInitialized())
+			{
+				unsigned int headOffset = pi1541.drive.GetHeadBitOffset();
+				diskVisualizer.UpdateHead(&screen, track, headOffset, led);
+			}
+
 			if (track != oldTrack)
 			{
 				oldTrack = track;

--- a/src/performance.c
+++ b/src/performance.c
@@ -223,7 +223,7 @@ void print_performance_counters(perf_counters_t *pct) {
 	int i;
 	uint64_t cycle_counter = pct->cycle_counter;
 	cycle_counter *= 64;
-	printf("%26s = %"PRIu64"\r\n", "cycle counter", cycle_counter);
+	printf("%26s = %llu\r\n", "cycle counter", (unsigned long long)cycle_counter);
 	for (i = 0; i < pct->num_counters; i++) {
 		printf("%26s = %u\r\n", type_lookup(pct->type[i]), pct->counter[i]);
 	}

--- a/src/types.h
+++ b/src/types.h
@@ -24,6 +24,12 @@ typedef enum {
 	EXIT_AUTOLOAD
 } EXIT_TYPE;
 
+typedef enum {
+	IEC_COMMANDS,
+	EMULATING_1541,
+	EMULATING_1581
+} EmulatingMode;
+
 #ifndef Max
 #define Max(a,b)	(((a) > (b)) ? (a) : (b))
 #endif


### PR DESCRIPTION
Add Real-time Disk Visualization
Replaces the old rectangular BAM grid with a circular floppy disk visualization that shows real-time drive activity.

Changes:

DiskVisualizer.h/cpp - New rendering engine with track/sector layout, BAM coloring, and animated read head
FileBrowser.cpp - Integrated into DisplayDiskInfo() for full disk render on load
main.cpp - Added UpdateHead() hook in UpdateScreen() for real-time head movement
Features:

Concentric rings show D64 track layout (21/19/18/17 sectors per track zone)
BAM-based coloring: green=allocated, black=free, cyan=directory track
Red highlighting for active sector during drive LED activity
Moving read head on south edge with current track number
Integer-only math (no floating point dependencies)
Files Added:

src/DiskVisualizer.h (91 lines)
src/DiskVisualizer.cpp (500+ lines)
Files Modified:

src/FileBrowser.cpp (+20 lines)
src/main.cpp (+5 lines)
See attached MP4 and screenshots for the visual improvements.

Tested on:
Pi Zero 2 W

https://github.com/user-attachments/assets/e2b36f51-8498-4f43-8f46-eb4d389e0858

<img width="4000" height="3000" alt="20260415_193331" src="https://github.com/user-attachments/assets/cacc2d41-b844-476a-8994-a089a3af78c9" />
